### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.1.3"
+version = "0.1.4"
 description = "A terminal user interface for managing hledger journal transactions"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Bump pyproject.toml version to 0.1.4 to match the GitHub release.