### PR TITLE
feat: add recurring transactions with hledger-based validation

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -13,6 +13,7 @@ from hledger_textual.config import load_theme, save_theme
 from hledger_textual.widgets.accounts_pane import AccountsPane
 from hledger_textual.widgets.budget_pane import BudgetPane
 from hledger_textual.widgets.info_pane import InfoPane
+from hledger_textual.widgets.recurring_pane import RecurringPane
 from hledger_textual.widgets.reports_pane import ReportsPane
 from hledger_textual.widgets.summary_pane import SummaryPane
 from hledger_textual.widgets.transactions_pane import TransactionsPane
@@ -21,6 +22,7 @@ from hledger_textual.widgets.transactions_table import TransactionsTable
 _FOOTER_COMMANDS: dict[str, str] = {
     "summary": "\\[r] Reload  \\[s] Sync  \\[q] Quit",
     "transactions": "\\[a] Add  \\[e] Edit  \\[d] Delete  \\[◄/►] Month  \\[t] Today  \\[/] Search  \\[r] Reload  \\[s] Sync  \\[q] Quit",
+    "recurring": "\\[a] Add  \\[e] Edit  \\[d] Delete  \\[g] Generate  \\[/] Search  \\[r] Reload  \\[s] Sync  \\[q] Quit",
     "accounts": "\\[↵] Drill  \\[/] Search  \\[r] Reload  \\[s] Sync  \\[q] Quit",
     "budget": "\\[a] Add  \\[e] Edit  \\[d] Delete  \\[◄/►] Month  \\[t] Today  \\[/] Search  \\[s] Sync  \\[q] Quit",
     "reports": "\\[c] Chart  \\[i] Inv  \\[r] Reload  \\[s] Sync  \\[q] Quit",
@@ -55,10 +57,11 @@ class HledgerTuiApp(App):
     BINDINGS = [
         Binding("1", "switch_section('summary')", "Summary", show=False),
         Binding("2", "switch_section('transactions')", "Transactions", show=False),
-        Binding("3", "switch_section('budget')", "Budget", show=False),
-        Binding("4", "switch_section('reports')", "Reports", show=False),
-        Binding("5", "switch_section('accounts')", "Accounts", show=False),
-        Binding("6", "switch_section('info')", "Info", show=False),
+        Binding("3", "switch_section('recurring')", "Recurring", show=False),
+        Binding("4", "switch_section('budget')", "Budget", show=False),
+        Binding("5", "switch_section('reports')", "Reports", show=False),
+        Binding("6", "switch_section('accounts')", "Accounts", show=False),
+        Binding("7", "switch_section('info')", "Info", show=False),
         Binding("s", "git_sync", "Sync", show=False),
         Binding("q", "quit", "Quit"),
         Binding("t", "pick_theme", "Theme", show=False),
@@ -81,16 +84,18 @@ class HledgerTuiApp(App):
         yield _NavTabs(
             _NavTab("1. Summary", id="tab-summary"),
             _NavTab("2. Transactions", id="tab-transactions"),
-            _NavTab("3. Budget", id="tab-budget"),
-            _NavTab("4. Reports", id="tab-reports"),
-            _NavTab("5. Accounts", id="tab-accounts"),
-            _NavTab("6. Info", id="tab-info"),
+            _NavTab("3. Recurring", id="tab-recurring"),
+            _NavTab("4. Budget", id="tab-budget"),
+            _NavTab("5. Reports", id="tab-reports"),
+            _NavTab("6. Accounts", id="tab-accounts"),
+            _NavTab("7. Info", id="tab-info"),
             id="nav-tabs",
         )
 
         with ContentSwitcher(initial="summary", id="content-switcher"):
             yield SummaryPane(self.journal_file, id="summary")
             yield TransactionsPane(self.journal_file, id="transactions")
+            yield RecurringPane(self.journal_file, id="recurring")
             yield BudgetPane(self.journal_file, id="budget")
             yield ReportsPane(self.journal_file, id="reports")
             yield AccountsPane(self.journal_file, id="accounts")
@@ -123,6 +128,8 @@ class HledgerTuiApp(App):
             self.query_one("#summary-breakdown-table", DataTable).focus()
         elif section == "transactions":
             self.query_one(TransactionsTable).query_one(DataTable).focus()
+        elif section == "recurring":
+            self.query_one("#recurring-table", DataTable).focus()
         elif section == "accounts":
             self.query_one("#accounts-table", DataTable).focus()
         elif section == "budget":

--- a/src/hledger_textual/dateutil.py
+++ b/src/hledger_textual/dateutil.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import calendar
 from datetime import date
 
 
@@ -33,3 +34,35 @@ def next_month(d: date) -> date:
     if month > 12:
         month, year = 1, year + 1
     return d.replace(year=year, month=month, day=1)
+
+
+def add_months(d: date, months: int) -> date:
+    """Return *d* shifted by *months* months, clamping day to the last valid day.
+
+    Args:
+        d: The starting date.
+        months: Number of months to add (may be negative).
+
+    Returns:
+        A new date shifted by the given number of months.
+    """
+    total_months = d.year * 12 + (d.month - 1) + months
+    year = total_months // 12
+    month = total_months % 12 + 1
+    max_day = calendar.monthrange(year, month)[1]
+    return d.replace(year=year, month=month, day=min(d.day, max_day))
+
+
+def add_years(d: date, years: int) -> date:
+    """Return *d* shifted by *years* years, clamping day to the last valid day.
+
+    Args:
+        d: The starting date.
+        years: Number of years to add (may be negative).
+
+    Returns:
+        A new date shifted by the given number of years.
+    """
+    year = d.year + years
+    max_day = calendar.monthrange(year, d.month)[1]
+    return d.replace(year=year, day=min(d.day, max_day))

--- a/src/hledger_textual/models.py
+++ b/src/hledger_textual/models.py
@@ -176,6 +176,20 @@ class BudgetRule:
 
 
 @dataclass
+class RecurringRule:
+    """A recurring transaction rule with period expression and full transaction details."""
+
+    rule_id: str
+    period_expr: str
+    description: str
+    postings: list[Posting] = field(default_factory=list)
+    status: TransactionStatus = TransactionStatus.UNMARKED
+    code: str = ""
+    comment: str = ""
+    last_generated: str | None = None
+
+
+@dataclass
 class BudgetRow:
     """A row in the budget report comparing actual vs budgeted spending."""
 

--- a/src/hledger_textual/recurring.py
+++ b/src/hledger_textual/recurring.py
@@ -1,0 +1,487 @@
+"""Recurring transaction file management: read/write periodic transactions.
+
+Recurring rules are stored as hledger periodic transactions (``~ period``)
+in a dedicated ``recurring.journal`` file that lives next to the main journal.
+All write operations follow the same backup/validate/restore pattern used
+in ``budget.py`` and ``journal.py``.
+"""
+
+from __future__ import annotations
+
+import random
+import re
+import string
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+from hledger_textual.fileutil import backup as _backup
+from hledger_textual.fileutil import cleanup_backup as _cleanup_backup
+from hledger_textual.fileutil import restore as _restore
+from hledger_textual.hledger import HledgerError, check_journal
+from hledger_textual.models import (
+    Amount,
+    AmountStyle,
+    Posting,
+    RecurringRule,
+    TransactionStatus,
+)
+
+RECURRING_FILENAME = "recurring.journal"
+
+_INCLUDE_RE = re.compile(r"^\s*include\s+recurring\.journal\s*$", re.MULTILINE)
+
+# ~ period_expr  description  ; comment
+_PERIODIC_RE = re.compile(r"^~\s+(.+?)\s{2,}(.+?)(?:\s{2,};\s*(.*))?$")
+
+# Posting with amount: account  amount  ; comment
+_POSTING_RE = re.compile(r"^\s{4,}(\S.+?)\s{2,}(\S+)\s*(?:;\s*(.*))?$")
+
+# Balancing posting without amount
+_BALANCING_RE = re.compile(r"^\s{4,}(\S[^\s;]*)\s*$")
+
+
+class RecurringError(Exception):
+    """Raised when a recurring file operation fails."""
+
+
+def _recurring_path(journal_file: Path) -> Path:
+    """Return the path to recurring.journal next to the main journal."""
+    return journal_file.parent / RECURRING_FILENAME
+
+
+def ensure_recurring_file(journal_file: Path) -> Path:
+    """Create recurring.journal if missing and add include directive to the main journal.
+
+    Args:
+        journal_file: Path to the main hledger journal file.
+
+    Returns:
+        Path to the recurring.journal file.
+    """
+    recurring_file = _recurring_path(journal_file)
+
+    if not recurring_file.exists():
+        recurring_file.write_text("")
+
+    journal_text = journal_file.read_text()
+    if not _INCLUDE_RE.search(journal_text):
+        include_line = f"include {RECURRING_FILENAME}\n"
+        if journal_text and not journal_text.startswith("\n"):
+            include_line += "\n"
+        journal_file.write_text(include_line + journal_text)
+
+    return recurring_file
+
+
+def _parse_amount_string(s: str) -> tuple[Decimal, str]:
+    """Parse an amount string like '€800.00' or '150.00 EUR' into (quantity, commodity).
+
+    Args:
+        s: The amount string to parse.
+
+    Returns:
+        A tuple of (quantity, commodity).
+
+    Raises:
+        RecurringError: If the amount cannot be parsed.
+    """
+    s = s.strip()
+    if not s:
+        raise RecurringError("Empty amount string")
+
+    # Try left-side commodity: €800.00 or $500
+    match = re.match(r"^([^\d\s.-]+)\s*(-?[\d.]+)$", s)
+    if match:
+        commodity = match.group(1)
+        try:
+            quantity = Decimal(match.group(2))
+        except InvalidOperation:
+            raise RecurringError(f"Invalid amount: {s}")
+        return quantity, commodity
+
+    # Try right-side commodity: 800.00 EUR
+    match = re.match(r"^(-?[\d.]+)\s*([^\d\s.-]+)$", s)
+    if match:
+        try:
+            quantity = Decimal(match.group(1))
+        except InvalidOperation:
+            raise RecurringError(f"Invalid amount: {s}")
+        commodity = match.group(2)
+        return quantity, commodity
+
+    raise RecurringError(f"Cannot parse amount: {s}")
+
+
+def _parse_metadata(comment: str) -> dict[str, str]:
+    """Parse key:value pairs from a comment string.
+
+    Args:
+        comment: The comment string (e.g. "recurring-id:rent-001, last-generated:2026-02-01").
+
+    Returns:
+        Dictionary of parsed key-value pairs.
+    """
+    metadata: dict[str, str] = {}
+    if not comment:
+        return metadata
+    for part in comment.split(","):
+        part = part.strip()
+        if ":" in part:
+            key, _, value = part.partition(":")
+            metadata[key.strip()] = value.strip()
+    return metadata
+
+
+def _status_from_string(s: str) -> TransactionStatus:
+    """Parse a transaction status from a string symbol.
+
+    Args:
+        s: The status symbol ('*', '!', or empty).
+
+    Returns:
+        The corresponding TransactionStatus.
+    """
+    s = s.strip()
+    if s == "*":
+        return TransactionStatus.CLEARED
+    if s == "!":
+        return TransactionStatus.PENDING
+    return TransactionStatus.UNMARKED
+
+
+def parse_recurring_rules(recurring_path: Path) -> list[RecurringRule]:
+    """Parse recurring rules from a recurring.journal file.
+
+    Args:
+        recurring_path: Path to the recurring.journal file.
+
+    Returns:
+        A list of RecurringRule objects.
+    """
+    if not recurring_path.exists():
+        return []
+
+    content = recurring_path.read_text()
+    if not content.strip():
+        return []
+
+    rules: list[RecurringRule] = []
+    current_rule: RecurringRule | None = None
+
+    for line in content.splitlines():
+        periodic_match = _PERIODIC_RE.match(line)
+        if periodic_match:
+            # Save previous rule if any
+            if current_rule is not None:
+                rules.append(current_rule)
+
+            period_expr = periodic_match.group(1).strip()
+            description_raw = periodic_match.group(2).strip()
+            comment_raw = periodic_match.group(3) or ""
+
+            # Parse metadata from comment
+            metadata = _parse_metadata(comment_raw)
+            rule_id = metadata.get("recurring-id", "")
+            last_generated = metadata.get("last-generated") or None
+
+            # Extract status symbol from description if present
+            status = TransactionStatus.UNMARKED
+            desc = description_raw
+            if desc.startswith("* "):
+                status = TransactionStatus.CLEARED
+                desc = desc[2:]
+            elif desc.startswith("! "):
+                status = TransactionStatus.PENDING
+                desc = desc[2:]
+
+            # Extract code from description: "(CODE) rest"
+            code = ""
+            code_match = re.match(r"^\(([^)]*)\)\s*(.*)", desc)
+            if code_match:
+                code = code_match.group(1)
+                desc = code_match.group(2)
+
+            # Build user comment (everything except our internal tags)
+            user_comment_parts = []
+            for part in comment_raw.split(","):
+                part = part.strip()
+                if part and not part.startswith("recurring-id:") and not part.startswith("last-generated:"):
+                    user_comment_parts.append(part)
+            user_comment = ", ".join(user_comment_parts)
+
+            current_rule = RecurringRule(
+                rule_id=rule_id,
+                period_expr=period_expr,
+                description=desc,
+                status=status,
+                code=code,
+                comment=user_comment,
+                last_generated=last_generated,
+            )
+            continue
+
+        if current_rule is not None:
+            # End of block: non-indented, non-empty line that isn't a tilde
+            if line and not line[0].isspace() and not line.startswith("~"):
+                rules.append(current_rule)
+                current_rule = None
+                continue
+
+            # Empty line within/between blocks
+            if not line.strip():
+                continue
+
+            # Try posting with amount
+            posting_match = _POSTING_RE.match(line)
+            if posting_match:
+                account = posting_match.group(1).strip()
+                amount_str = posting_match.group(2).strip()
+                posting_comment = posting_match.group(3) or ""
+                quantity, commodity = _parse_amount_string(amount_str)
+                exp = quantity.as_tuple().exponent
+                precision = max(abs(exp) if isinstance(exp, int) else 2, 2)
+                style = AmountStyle(
+                    commodity_side="L",
+                    commodity_spaced=False,
+                    precision=precision,
+                )
+                current_rule.postings.append(
+                    Posting(
+                        account=account,
+                        amounts=[Amount(commodity=commodity, quantity=quantity, style=style)],
+                        comment=posting_comment.strip(),
+                    )
+                )
+                continue
+
+            # Try balancing posting (no amount)
+            balancing_match = _BALANCING_RE.match(line)
+            if balancing_match:
+                account = balancing_match.group(1).strip()
+                current_rule.postings.append(Posting(account=account))
+                continue
+
+    # Don't forget the last rule
+    if current_rule is not None:
+        rules.append(current_rule)
+
+    return rules
+
+
+def _format_recurring_file(rules: list[RecurringRule]) -> str:
+    """Format recurring rules into the recurring.journal file content.
+
+    Args:
+        rules: The recurring rules to format.
+
+    Returns:
+        The formatted file content.
+    """
+    if not rules:
+        return ""
+
+    blocks: list[str] = []
+
+    for rule in rules:
+        # Build the tilde header line
+        # ~ period_expr  [status] [(code)] description  ; metadata
+        desc_parts: list[str] = []
+        if rule.status != TransactionStatus.UNMARKED:
+            desc_parts.append(rule.status.symbol)
+        if rule.code:
+            desc_parts.append(f"({rule.code})")
+        desc_parts.append(rule.description)
+        desc = " ".join(desc_parts)
+
+        # Build comment with metadata
+        comment_parts: list[str] = []
+        if rule.rule_id:
+            comment_parts.append(f"recurring-id:{rule.rule_id}")
+        if rule.last_generated:
+            comment_parts.append(f"last-generated:{rule.last_generated}")
+        if rule.comment:
+            comment_parts.append(rule.comment)
+
+        header = f"~ {rule.period_expr}  {desc}"
+        if comment_parts:
+            header += f"  ; {', '.join(comment_parts)}"
+
+        lines = [header]
+
+        # Calculate alignment widths
+        if rule.postings:
+            max_account = max(len(p.account) for p in rule.postings)
+            account_width = max(max_account + 4, 40)
+        else:
+            account_width = 40
+
+        for posting in rule.postings:
+            if posting.amounts:
+                amount_str = posting.amounts[0].format()
+                padding = " " * (account_width - len(posting.account))
+                posting_line = f"    {posting.account}{padding}{amount_str}"
+            else:
+                posting_line = f"    {posting.account}"
+
+            if posting.comment:
+                posting_line += f"  ; {posting.comment}"
+
+            lines.append(posting_line)
+
+        blocks.append("\n".join(lines))
+
+    return "\n\n".join(blocks) + "\n"
+
+
+def write_recurring_rules(
+    recurring_path: Path, rules: list[RecurringRule], journal_file: Path
+) -> None:
+    """Write recurring rules to the recurring.journal file.
+
+    Uses backup/validate/restore pattern for safety.
+
+    Args:
+        recurring_path: Path to the recurring.journal file.
+        rules: The recurring rules to write.
+        journal_file: Path to the main journal file (for validation).
+
+    Raises:
+        RecurringError: If validation fails (file is restored from backup).
+    """
+    backup_path = _backup(recurring_path)
+
+    try:
+        content = _format_recurring_file(rules)
+        recurring_path.write_text(content)
+
+        try:
+            check_journal(journal_file)
+        except HledgerError as exc:
+            _restore(recurring_path, backup_path)
+            _cleanup_backup(backup_path)
+            raise RecurringError(f"Recurring validation failed, changes reverted: {exc}")
+
+        _cleanup_backup(backup_path)
+    except RecurringError:
+        raise
+    except Exception as exc:
+        _restore(recurring_path, backup_path)
+        _cleanup_backup(backup_path)
+        raise RecurringError(f"Failed to write recurring rules: {exc}")
+
+
+def add_recurring_rule(
+    recurring_path: Path, rule: RecurringRule, journal_file: Path
+) -> None:
+    """Add a new recurring rule.
+
+    Args:
+        recurring_path: Path to the recurring.journal file.
+        rule: The recurring rule to add.
+        journal_file: Path to the main journal file.
+
+    Raises:
+        RecurringError: If a rule with the same ID already exists or validation fails.
+    """
+    rules = parse_recurring_rules(recurring_path)
+    if any(r.rule_id == rule.rule_id for r in rules):
+        raise RecurringError(f"Recurring rule already exists with id {rule.rule_id}")
+    rules.append(rule)
+    write_recurring_rules(recurring_path, rules, journal_file)
+
+
+def update_recurring_rule(
+    recurring_path: Path,
+    old_rule_id: str,
+    new_rule: RecurringRule,
+    journal_file: Path,
+) -> None:
+    """Update an existing recurring rule.
+
+    Args:
+        recurring_path: Path to the recurring.journal file.
+        old_rule_id: The rule_id of the rule to update.
+        new_rule: The new recurring rule.
+        journal_file: Path to the main journal file.
+
+    Raises:
+        RecurringError: If the rule is not found or validation fails.
+    """
+    rules = parse_recurring_rules(recurring_path)
+    found = False
+    for i, r in enumerate(rules):
+        if r.rule_id == old_rule_id:
+            rules[i] = new_rule
+            found = True
+            break
+    if not found:
+        raise RecurringError(f"No recurring rule found with id {old_rule_id}")
+    write_recurring_rules(recurring_path, rules, journal_file)
+
+
+def delete_recurring_rule(
+    recurring_path: Path, rule_id: str, journal_file: Path
+) -> None:
+    """Delete a recurring rule by rule_id.
+
+    Args:
+        recurring_path: Path to the recurring.journal file.
+        rule_id: The rule_id of the rule to delete.
+        journal_file: Path to the main journal file.
+
+    Raises:
+        RecurringError: If the rule is not found or validation fails.
+    """
+    rules = parse_recurring_rules(recurring_path)
+    new_rules = [r for r in rules if r.rule_id != rule_id]
+    if len(new_rules) == len(rules):
+        raise RecurringError(f"No recurring rule found with id {rule_id}")
+    write_recurring_rules(recurring_path, new_rules, journal_file)
+
+
+def update_last_generated(
+    recurring_path: Path, rule_id: str, date_str: str, journal_file: Path
+) -> None:
+    """Update only the last_generated date for a specific rule.
+
+    Args:
+        recurring_path: Path to the recurring.journal file.
+        rule_id: The rule_id of the rule to update.
+        date_str: The new last_generated date string (ISO format).
+        journal_file: Path to the main journal file.
+
+    Raises:
+        RecurringError: If the rule is not found or validation fails.
+    """
+    rules = parse_recurring_rules(recurring_path)
+    found = False
+    for rule in rules:
+        if rule.rule_id == rule_id:
+            rule.last_generated = date_str
+            found = True
+            break
+    if not found:
+        raise RecurringError(f"No recurring rule found with id {rule_id}")
+    write_recurring_rules(recurring_path, rules, journal_file)
+
+
+def generate_rule_id(description: str) -> str:
+    """Generate a unique rule ID from a description.
+
+    Creates a slug from the description and appends a random suffix.
+
+    Args:
+        description: The rule description.
+
+    Returns:
+        A rule ID string like "rent-payment-a1b2".
+    """
+    # Create slug from description
+    slug = re.sub(r"[^a-z0-9]+", "-", description.lower()).strip("-")
+    if not slug:
+        slug = "rule"
+    # Truncate long slugs
+    slug = slug[:30]
+    # Add random suffix
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    return f"{slug}-{suffix}"

--- a/src/hledger_textual/recurring_engine.py
+++ b/src/hledger_textual/recurring_engine.py
@@ -1,0 +1,240 @@
+"""Recurring transaction engine: date computation and transaction generation.
+
+Delegates period expression validation and date computation to hledger,
+enabling support for any hledger period expression (e.g. ``every 3rd thursday``,
+``every friday``, ``every feb 14``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import tempfile
+from datetime import date, timedelta
+
+from hledger_textual.models import (
+    Posting,
+    RecurringRule,
+    Transaction,
+    TransactionStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def validate_period_expression(period_expr: str) -> tuple[bool, str]:
+    """Validate a period expression using hledger check.
+
+    Writes a minimal periodic transaction rule to a temporary file and asks
+    hledger to check it.  This supports the full range of hledger period
+    expressions.
+
+    Args:
+        period_expr: The period expression to validate.
+
+    Returns:
+        A tuple of ``(is_valid, error_message)``.  ``error_message`` is empty
+        when the expression is valid.
+    """
+    expr = period_expr.strip()
+    if not expr:
+        return (False, "Period expression is empty")
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".journal", delete=True
+    ) as f:
+        f.write(f"~ {expr}\n    a  $1\n    b\n")
+        f.flush()
+
+        try:
+            result = subprocess.run(
+                ["hledger", "check", "-f", f.name],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except FileNotFoundError:
+            return (False, "hledger is not installed")
+        except subprocess.TimeoutExpired:
+            return (False, "Validation timed out")
+
+    if result.returncode == 0:
+        return (True, "")
+
+    # Extract the most descriptive error line from stderr.
+    stderr = result.stderr.strip()
+    lines = stderr.splitlines()
+    for line in lines:
+        lower = line.lower()
+        if "unexpected" in lower or "expecting" in lower:
+            return (False, line.strip())
+    error = lines[-1].strip() if lines else "Unknown validation error"
+    return (False, error)
+
+
+def compute_all_due_dates(
+    period_expr: str,
+    last_generated: str | None,
+    up_to: date,
+) -> list[date]:
+    """Compute all due dates between *last_generated* and *up_to* (inclusive).
+
+    Uses ``hledger print --forecast`` to compute dates.  When
+    *last_generated* is provided, the period expression is anchored with a
+    ``from <last_generated>`` clause so that hledger generates dates aligned
+    to the original schedule.
+
+    Args:
+        period_expr: The period expression (e.g. ``"monthly"``,
+            ``"every friday"``).
+        last_generated: ISO date string of the last generation, or ``None``.
+        up_to: The upper bound date (inclusive).
+
+    Returns:
+        A sorted list of due dates.
+    """
+    if last_generated:
+        start_date = date.fromisoformat(last_generated) + timedelta(days=1)
+        period_line = f"~ {period_expr} from {last_generated}"
+    else:
+        start_date = up_to.replace(day=1)
+        period_line = f"~ {period_expr}"
+
+    end_date = up_to + timedelta(days=1)  # hledger forecast end is exclusive
+
+    if start_date >= end_date:
+        return []
+
+    forecast_range = f"{start_date.isoformat()}..{end_date.isoformat()}"
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".journal", delete=True
+    ) as f:
+        f.write(f"{period_line}\n    a  $1\n    b\n")
+        f.flush()
+
+        try:
+            result = subprocess.run(
+                [
+                    "hledger",
+                    "print",
+                    f"--forecast={forecast_range}",
+                    "-f",
+                    f.name,
+                    "-O",
+                    "json",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            logger.warning(
+                "hledger not available or timed out for date computation"
+            )
+            return []
+
+    if result.returncode != 0:
+        logger.warning("hledger forecast failed: %s", result.stderr.strip())
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse hledger JSON output")
+        return []
+
+    return sorted(date.fromisoformat(txn["tdate"]) for txn in data)
+
+
+def compute_next_due_date(
+    period_expr: str,
+    last_generated: str | None,
+    reference_date: date | None = None,
+) -> date | None:
+    """Compute the next due date for a recurring rule.
+
+    Delegates to :func:`compute_all_due_dates` and returns the earliest date.
+
+    Args:
+        period_expr: The period expression (e.g. ``"monthly"``).
+        last_generated: ISO date string of the last generation, or ``None``.
+        reference_date: The reference "today" date (defaults to today).
+
+    Returns:
+        The next due date, or ``None`` if no date is due yet.
+    """
+    if reference_date is None:
+        reference_date = date.today()
+
+    dates = compute_all_due_dates(period_expr, last_generated, reference_date)
+    return dates[0] if dates else None
+
+
+def find_pending_generations(
+    rules: list[RecurringRule],
+    up_to: date | None = None,
+) -> list[tuple[RecurringRule, list[date]]]:
+    """Find all rules with pending (ungenerated) transactions.
+
+    Args:
+        rules: The list of recurring rules.
+        up_to: The upper bound date (defaults to today).
+
+    Returns:
+        A list of (rule, pending_dates) tuples, only for rules with pending dates.
+    """
+    if up_to is None:
+        up_to = date.today()
+
+    result: list[tuple[RecurringRule, list[date]]] = []
+    for rule in rules:
+        dates = compute_all_due_dates(rule.period_expr, rule.last_generated, up_to)
+        if dates:
+            result.append((rule, dates))
+    return result
+
+
+def build_transaction_from_rule(rule: RecurringRule, target_date: date) -> Transaction:
+    """Build a Transaction object from a recurring rule for a specific date.
+
+    The generated transaction includes a comment with recurring metadata
+    for traceability.
+
+    Args:
+        rule: The recurring rule.
+        target_date: The date for the generated transaction.
+
+    Returns:
+        A Transaction object ready to be appended to the journal.
+    """
+    # Build comment with recurring metadata
+    comment_parts: list[str] = []
+    comment_parts.append(f"recurring-id:{rule.rule_id}")
+    comment_parts.append(f"recurring-date:{target_date.isoformat()}")
+    if rule.comment:
+        comment_parts.append(rule.comment)
+    comment = ", ".join(comment_parts)
+
+    # Deep copy postings
+    postings: list[Posting] = []
+    for p in rule.postings:
+        postings.append(
+            Posting(
+                account=p.account,
+                amounts=list(p.amounts),
+                comment=p.comment,
+                status=p.status,
+            )
+        )
+
+    return Transaction(
+        index=0,
+        date=target_date.isoformat(),
+        description=rule.description,
+        status=rule.status,
+        code=rule.code,
+        comment=comment,
+        postings=postings,
+    )

--- a/src/hledger_textual/screens/recurring_delete_confirm.py
+++ b/src/hledger_textual/screens/recurring_delete_confirm.py
@@ -1,0 +1,49 @@
+"""Delete confirmation modal for recurring rules."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+from hledger_textual.models import RecurringRule
+
+
+class RecurringDeleteConfirmModal(ModalScreen[bool]):
+    """A modal dialog to confirm recurring rule deletion."""
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, rule: RecurringRule) -> None:
+        """Initialize the modal.
+
+        Args:
+            rule: The recurring rule to confirm deletion of.
+        """
+        super().__init__()
+        self.rule = rule
+
+    def compose(self) -> ComposeResult:
+        """Create the modal layout."""
+        summary = f"{self.rule.period_expr}  {self.rule.description}"
+
+        with Vertical(id="recurring-delete-dialog"):
+            yield Label("Delete Recurring Rule?", id="recurring-delete-title")
+            yield Static(summary, id="recurring-delete-summary")
+            with Horizontal(id="recurring-delete-buttons"):
+                yield Button("Delete", variant="error", id="btn-recurring-delete")
+                yield Button("Cancel", variant="default", id="btn-recurring-del-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        if event.button.id == "btn-recurring-delete":
+            self.dismiss(True)
+        else:
+            self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        """Cancel deletion."""
+        self.dismiss(False)

--- a/src/hledger_textual/screens/recurring_form.py
+++ b/src/hledger_textual/screens/recurring_form.py
@@ -1,0 +1,405 @@
+"""Recurring rule form modal for creating and editing recurring transaction rules."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.suggester import SuggestFromList
+from textual.timer import Timer
+from textual.widgets import Button, Input, Label, Select, Static
+
+from hledger_textual.config import load_default_commodity
+from hledger_textual.hledger import HledgerError, load_accounts, load_descriptions
+from hledger_textual.models import (
+    Amount,
+    AmountStyle,
+    Posting,
+    RecurringRule,
+    TransactionStatus,
+)
+from hledger_textual.recurring import generate_rule_id
+from hledger_textual.recurring_engine import validate_period_expression
+from hledger_textual.widgets.autocomplete_input import AutocompleteInput
+from hledger_textual.widgets.posting_row import PostingRow
+
+STATUS_OPTIONS = [
+    ("Unmarked", TransactionStatus.UNMARKED),
+    ("Pending (!)", TransactionStatus.PENDING),
+    ("Cleared (*)", TransactionStatus.CLEARED),
+]
+
+PERIOD_OPTIONS = [
+    ("Daily", "daily"),
+    ("Weekly", "weekly"),
+    ("Every 2 weeks", "every 2 weeks"),
+    ("Monthly", "monthly"),
+    ("Bimonthly", "bimonthly"),
+    ("Quarterly", "quarterly"),
+    ("Yearly", "yearly"),
+    ("Custom...", "__custom__"),
+]
+
+
+class RecurringFormScreen(ModalScreen[RecurringRule | None]):
+    """Centered modal form for creating or editing a recurring rule."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        journal_file: Path,
+        rule: RecurringRule | None = None,
+    ) -> None:
+        """Initialize the form modal.
+
+        Args:
+            journal_file: Path to the journal file.
+            rule: Existing recurring rule to edit, or None for new.
+        """
+        super().__init__()
+        self.journal_file = journal_file
+        self.rule = rule
+        self.posting_count = 0
+        self.accounts: list[str] = []
+        self._validation_timer: Timer | None = None
+
+    @property
+    def is_edit(self) -> bool:
+        """Whether this form is editing an existing rule."""
+        return self.rule is not None
+
+    def _initial_period_value(self) -> str:
+        """Return the initial period select value."""
+        if not self.is_edit or not self.rule:
+            return "monthly"
+        known = {val for _, val in PERIOD_OPTIONS if val != "__custom__"}
+        if self.rule.period_expr in known:
+            return self.rule.period_expr
+        return "__custom__"
+
+    def compose(self) -> ComposeResult:
+        """Create the modal form layout."""
+        title = "Edit Recurring Rule" if self.is_edit else "New Recurring Rule"
+
+        with Vertical(id="recurring-form-dialog"):
+            yield Static(title, id="recurring-form-title")
+
+            with VerticalScroll(id="recurring-form-scroll"):
+                # Period field
+                with Horizontal(classes="form-field"):
+                    yield Label("Period:")
+                    yield Select(
+                        options=PERIOD_OPTIONS,
+                        value=self._initial_period_value(),
+                        id="recurring-select-period",
+                    )
+
+                # Custom period field (hidden by default)
+                with Horizontal(classes="form-field custom-period-field"):
+                    yield Label("Custom:")
+                    yield Input(
+                        value=self.rule.period_expr if self.is_edit and self._initial_period_value() == "__custom__" else "",
+                        placeholder="e.g. every 3 months",
+                        id="recurring-input-custom-period",
+                    )
+
+                with Horizontal(classes="custom-period-hint-row"):
+                    yield Label("", classes="hint-spacer")
+                    yield Static("", id="custom-period-hint", classes="custom-period-hint")
+
+                # Description field
+                with Horizontal(classes="form-field"):
+                    yield Label("Description:")
+                    yield AutocompleteInput(
+                        value=self.rule.description if self.is_edit else "",
+                        placeholder="Transaction description",
+                        id="recurring-input-description",
+                    )
+
+                # Status field
+                with Horizontal(classes="form-field"):
+                    yield Label("Status:")
+                    initial_status = (
+                        self.rule.status if self.is_edit else TransactionStatus.UNMARKED
+                    )
+                    yield Select(
+                        options=STATUS_OPTIONS,
+                        value=initial_status,
+                        id="recurring-select-status",
+                    )
+
+                # Code field
+                with Horizontal(classes="form-field"):
+                    yield Label("Code:")
+                    yield Input(
+                        value=self.rule.code if self.is_edit else "",
+                        placeholder="Optional transaction code",
+                        id="recurring-input-code",
+                    )
+
+                # Comment field
+                with Horizontal(classes="form-field"):
+                    yield Label("Comment:")
+                    yield Input(
+                        value=self.rule.comment if self.is_edit else "",
+                        placeholder="Optional comment",
+                        id="recurring-input-comment",
+                    )
+
+                # Postings section
+                yield Static("Postings", id="recurring-postings-header")
+                yield Vertical(id="recurring-postings-container")
+
+                with Horizontal(id="recurring-posting-buttons"):
+                    yield Button("\\[+] Add posting", id="btn-recurring-add-posting")
+                    yield Button("\\[-] Remove last", id="btn-recurring-remove-posting")
+
+            with Horizontal(id="recurring-form-buttons"):
+                yield Button("Cancel", id="btn-recurring-cancel")
+                yield Button("Save", id="btn-recurring-save")
+
+    def on_mount(self) -> None:
+        """Load accounts and descriptions, set up initial posting rows."""
+        try:
+            self.accounts = load_accounts(self.journal_file)
+        except HledgerError:
+            self.accounts = []
+
+        try:
+            descriptions = load_descriptions(self.journal_file)
+        except HledgerError:
+            descriptions = []
+        if descriptions:
+            self.query_one("#recurring-input-description", AutocompleteInput).suggester = (
+                SuggestFromList(descriptions, case_sensitive=False)
+            )
+
+        # Show/hide custom period field
+        self._toggle_custom_period()
+
+        if self.is_edit and self.rule:
+            for i, posting in enumerate(self.rule.postings):
+                amount_str = ""
+                commodity = ""
+                if posting.amounts:
+                    amt = posting.amounts[0]
+                    amount_str = f"{amt.quantity:.2f}"
+                    commodity = amt.commodity
+                label = f"#{i + 1}:"
+                self._add_posting_row(
+                    label=label,
+                    account=posting.account,
+                    amount=amount_str,
+                    commodity=commodity,
+                )
+        else:
+            default_commodity = load_default_commodity()
+            self._add_posting_row(label="Debit:", commodity=default_commodity)
+            self._add_posting_row(label="Credit:", commodity=default_commodity)
+
+    def _toggle_custom_period(self) -> None:
+        """Show or hide the custom period input based on the select value."""
+        select = self.query_one("#recurring-select-period", Select)
+        custom_field = self.query_one(".custom-period-field")
+        if select.value == "__custom__":
+            custom_field.add_class("visible")
+        else:
+            custom_field.remove_class("visible")
+            self._update_hint("", "")
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Handle period select changes."""
+        if event.select.id == "recurring-select-period":
+            self._toggle_custom_period()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Handle input changes with debounced validation for custom period."""
+        if event.input.id != "recurring-input-custom-period":
+            return
+
+        if self._validation_timer:
+            self._validation_timer.stop()
+
+        value = event.value.strip()
+        if not value:
+            self._update_hint("", "")
+            return
+
+        self._validation_timer = self.set_timer(
+            0.3, lambda: self._validate_period(value)
+        )
+
+    @work(thread=True)
+    def _validate_period(self, expr: str) -> None:
+        """Run hledger validation in a background thread."""
+        is_valid, error = validate_period_expression(expr)
+        if is_valid:
+            self.app.call_from_thread(self._update_hint, "valid", f"Valid: {expr}")
+        else:
+            self.app.call_from_thread(self._update_hint, "invalid", error)
+
+    def _update_hint(self, state: str, message: str) -> None:
+        """Update the custom-period-hint label with validation feedback."""
+        hint = self.query_one("#custom-period-hint", Static)
+        hint_row = self.query_one(".custom-period-hint-row")
+        custom_field = self.query_one(".custom-period-field")
+        hint.update(message)
+        hint.remove_class("valid", "invalid")
+        if state:
+            hint.add_class(state)
+            hint_row.add_class("visible")
+            custom_field.add_class("has-hint")
+        else:
+            hint_row.remove_class("visible")
+            custom_field.remove_class("has-hint")
+
+    def _add_posting_row(
+        self,
+        label: str = "",
+        account: str = "",
+        amount: str = "",
+        commodity: str = "",
+    ) -> None:
+        """Add a new posting row to the form."""
+        container = self.query_one("#recurring-postings-container", Vertical)
+        if not label:
+            label = f"#{self.posting_count + 1}:"
+        row = PostingRow(
+            label=label,
+            account=account,
+            amount=amount,
+            commodity=commodity,
+            row_index=self.posting_count,
+            account_suggestions=self.accounts,
+        )
+        container.mount(row)
+        self.posting_count += 1
+
+    def _remove_last_posting_row(self) -> None:
+        """Remove the last posting row from the form."""
+        container = self.query_one("#recurring-postings-container", Vertical)
+        rows = container.query(PostingRow)
+        if len(rows) > 2:
+            rows.last().remove()
+            self.posting_count -= 1
+        else:
+            self.notify("Minimum 2 postings required", severity="warning", timeout=3)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        match event.button.id:
+            case "btn-recurring-add-posting":
+                self._add_posting_row()
+            case "btn-recurring-remove-posting":
+                self._remove_last_posting_row()
+            case "btn-recurring-save":
+                self._save()
+            case "btn-recurring-cancel":
+                self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        """Cancel the form."""
+        self.dismiss(None)
+
+    def _save(self) -> None:
+        """Validate and save the recurring rule."""
+        # Get period expression
+        period_select = self.query_one("#recurring-select-period", Select)
+        if period_select.value == "__custom__":
+            period_expr = self.query_one("#recurring-input-custom-period", Input).value.strip()
+            if not period_expr:
+                self.notify("Custom period expression is required", severity="error", timeout=3)
+                return
+            is_valid, error = validate_period_expression(period_expr)
+            if not is_valid:
+                self.notify(
+                    f"Invalid period: {error}",
+                    severity="error",
+                    timeout=3,
+                )
+                return
+        else:
+            period_expr = str(period_select.value)
+
+        description = self.query_one("#recurring-input-description", Input).value.strip()
+        if not description:
+            self.notify("Description is required", severity="error", timeout=3)
+            return
+
+        status = self.query_one("#recurring-select-status", Select).value
+        code = self.query_one("#recurring-input-code", Input).value.strip()
+        comment = self.query_one("#recurring-input-comment", Input).value.strip()
+
+        # Parse postings
+        container = self.query_one("#recurring-postings-container", Vertical)
+        posting_rows = list(container.query(PostingRow))
+
+        postings: list[Posting] = []
+        for row in posting_rows:
+            account = row.account
+            if not account:
+                continue
+
+            amounts: list[Amount] = []
+            if row.amount:
+                try:
+                    qty = Decimal(row.amount)
+                except InvalidOperation:
+                    self.notify(
+                        f"Invalid amount: {row.amount}",
+                        severity="error",
+                        timeout=3,
+                    )
+                    return
+
+                commodity = row.commodity or load_default_commodity()
+                style = AmountStyle(
+                    commodity_side="L" if not commodity[0].isdigit() else "R",
+                    commodity_spaced=len(commodity) > 1,
+                    precision=max(
+                        abs(qty.as_tuple().exponent)
+                        if isinstance(qty.as_tuple().exponent, int)
+                        else 2,
+                        2,
+                    ),
+                )
+                amounts.append(Amount(commodity=commodity, quantity=qty, style=style))
+
+            postings.append(Posting(account=account, amounts=amounts))
+
+        if len(postings) < 2:
+            self.notify(
+                "At least 2 postings with accounts are required",
+                severity="error",
+                timeout=3,
+            )
+            return
+
+        # Determine rule_id
+        if self.is_edit and self.rule:
+            rule_id = self.rule.rule_id
+            last_generated = self.rule.last_generated
+        else:
+            rule_id = generate_rule_id(description)
+            last_generated = None
+
+        rule = RecurringRule(
+            rule_id=rule_id,
+            period_expr=period_expr,
+            description=description,
+            postings=postings,
+            status=status if isinstance(status, TransactionStatus) else TransactionStatus.UNMARKED,
+            code=code,
+            comment=comment,
+            last_generated=last_generated,
+        )
+
+        self.dismiss(rule)

--- a/src/hledger_textual/screens/recurring_generate.py
+++ b/src/hledger_textual/screens/recurring_generate.py
@@ -1,0 +1,87 @@
+"""Generation confirmation modal for recurring transactions."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Label, Static
+
+from hledger_textual.models import RecurringRule
+
+
+class RecurringGenerateScreen(ModalScreen[bool]):
+    """A modal dialog showing pending recurring transactions for confirmation."""
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        pending: list[tuple[RecurringRule, list[date]]],
+    ) -> None:
+        """Initialize the modal.
+
+        Args:
+            pending: List of (rule, dates) tuples for pending generations.
+        """
+        super().__init__()
+        self.pending = pending
+
+    def compose(self) -> ComposeResult:
+        """Create the modal layout."""
+        total = sum(len(dates) for _, dates in self.pending)
+
+        with Vertical(id="recurring-generate-dialog"):
+            yield Label(
+                "Generate Recurring Transactions",
+                id="recurring-generate-title",
+            )
+
+            yield DataTable(id="recurring-generate-table")
+
+            yield Static(
+                f"{total} transaction{'s' if total != 1 else ''} will be added to your journal",
+                id="recurring-generate-summary",
+            )
+
+            with Horizontal(id="recurring-generate-buttons"):
+                yield Button("Cancel", variant="default", id="btn-recurring-gen-cancel")
+                yield Button("Generate All", variant="success", id="btn-recurring-generate")
+
+    def on_mount(self) -> None:
+        """Populate the preview table."""
+        table = self.query_one("#recurring-generate-table", DataTable)
+        table.cursor_type = "none"
+        table.add_column("Period", width=16)
+        table.add_column("Description", width=24)
+        table.add_column("Date", width=12)
+        table.add_column("Amount", width=14)
+
+        for rule, dates in self.pending:
+            # Get the primary amount for display
+            amount_str = ""
+            if rule.postings and rule.postings[0].amounts:
+                amount_str = rule.postings[0].amounts[0].format()
+
+            for d in dates:
+                table.add_row(
+                    rule.period_expr,
+                    rule.description,
+                    d.isoformat(),
+                    amount_str,
+                )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        if event.button.id == "btn-recurring-generate":
+            self.dismiss(True)
+        else:
+            self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        """Cancel generation."""
+        self.dismiss(False)

--- a/src/hledger_textual/styles/app.tcss
+++ b/src/hledger_textual/styles/app.tcss
@@ -222,11 +222,21 @@ AccountsPane {
     padding-top: 1;
 }
 
-AccountsPane .filter-bar {
-    dock: top;
+#accounts-toolbar-content {
+    width: 1fr;
     height: 3;
-    margin-bottom: 1;
+    align: left middle;
+}
+
+#accounts-toolbar-content.hidden {
+    display: none;
+}
+
+#accounts-title {
+    text-style: bold;
+    color: $accent;
     padding: 0 1;
+    height: 1;
 }
 
 #accounts-table {
@@ -534,6 +544,243 @@ BudgetDeleteConfirmModal {
 
 #btn-budget-delete {
     background: $error;
+}
+
+/* --- Recurring Pane --- */
+
+RecurringPane {
+    height: 1fr;
+    layout: vertical;
+    padding-top: 1;
+}
+
+#recurring-toolbar-content {
+    width: 1fr;
+    height: 3;
+    align: left middle;
+}
+
+#recurring-toolbar-content.hidden {
+    display: none;
+}
+
+#recurring-title {
+    text-style: bold;
+    color: $accent;
+    padding: 0 1;
+    height: 1;
+}
+
+#recurring-table {
+    height: 1fr;
+}
+
+/* --- Recurring Form Modal --- */
+
+RecurringFormScreen {
+    align: center middle;
+    background: $surface 60%;
+}
+
+#recurring-form-dialog {
+    width: 80;
+    max-width: 90%;
+    height: auto;
+    max-height: 85%;
+    border: thick $accent;
+    background: $surface;
+    padding: 1 2;
+}
+
+#recurring-form-title {
+    text-style: bold;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 1;
+    color: $accent;
+}
+
+#recurring-form-scroll {
+    height: auto;
+    max-height: 100%;
+}
+
+.custom-period-field {
+    display: none;
+}
+
+.custom-period-field.visible {
+    display: block;
+}
+
+.custom-period-field.has-hint {
+    margin-bottom: 0;
+}
+
+.custom-period-hint-row {
+    height: auto;
+    margin-bottom: 1;
+    display: none;
+}
+
+.custom-period-hint-row.visible {
+    display: block;
+}
+
+.hint-spacer {
+    width: 14;
+    margin-right: 1;
+    height: 1;
+}
+
+.custom-period-hint {
+    height: auto;
+    width: 1fr;
+}
+
+.custom-period-hint.valid {
+    color: green;
+}
+
+.custom-period-hint.invalid {
+    color: tomato;
+}
+
+#recurring-postings-header {
+    text-style: bold;
+    margin-top: 1;
+    margin-bottom: 1;
+}
+
+#recurring-postings-container {
+    height: auto;
+}
+
+#recurring-posting-buttons {
+    height: auto;
+    margin-top: 0;
+}
+
+#recurring-posting-buttons Button {
+    margin-right: 1;
+    height: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    color: $text-muted;
+}
+
+#recurring-posting-buttons Button:hover {
+    color: $text;
+    text-style: bold;
+}
+
+#recurring-posting-buttons Button:focus {
+    color: $accent;
+    text-style: bold;
+}
+
+#recurring-form-buttons {
+    height: 3;
+    layout: horizontal;
+    align: right middle;
+    padding: 0 1;
+    margin-top: 1;
+    dock: bottom;
+    background: $surface;
+}
+
+#recurring-form-buttons Button {
+    margin: 0 1;
+}
+
+/* --- Recurring Delete Confirmation Modal --- */
+
+RecurringDeleteConfirmModal {
+    align: center middle;
+    background: $surface 60%;
+}
+
+#recurring-delete-dialog {
+    width: 60;
+    height: auto;
+    max-height: 20;
+    border: thick $error;
+    background: $surface;
+    padding: 1 2;
+}
+
+#recurring-delete-title {
+    text-style: bold;
+    color: $error;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 1;
+}
+
+#recurring-delete-summary {
+    margin-bottom: 1;
+    height: auto;
+}
+
+#recurring-delete-buttons {
+    height: 3;
+    align: center middle;
+}
+
+#recurring-delete-buttons Button {
+    margin: 0 1;
+}
+
+#btn-recurring-delete {
+    background: $error;
+}
+
+/* --- Recurring Generate Modal --- */
+
+RecurringGenerateScreen {
+    align: center middle;
+    background: $surface 60%;
+}
+
+#recurring-generate-dialog {
+    width: 80;
+    max-width: 90%;
+    height: auto;
+    max-height: 60%;
+    border: thick $accent;
+    background: $surface;
+    padding: 1 2;
+}
+
+#recurring-generate-title {
+    text-style: bold;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 1;
+    color: $accent;
+}
+
+#recurring-generate-table {
+    height: auto;
+    max-height: 16;
+}
+
+#recurring-generate-summary {
+    width: 100%;
+    text-align: center;
+    margin-top: 1;
+    margin-bottom: 1;
+    color: $text-muted;
+}
+
+#recurring-generate-buttons {
+    height: 3;
+    align: center middle;
+}
+
+#recurring-generate-buttons Button {
+    margin: 0 1;
 }
 
 /* --- Reports Pane --- */

--- a/src/hledger_textual/widgets/accounts_pane.py
+++ b/src/hledger_textual/widgets/accounts_pane.py
@@ -9,10 +9,11 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.widget import Widget
-from textual.widgets import DataTable, Input
+from textual.widgets import DataTable, Input, Static
 
 from hledger_textual.hledger import HledgerError, load_account_balances
 from hledger_textual.widgets import distribute_column_widths
+from hledger_textual.widgets.pane_toolbar import PaneToolbar
 
 
 class AccountsPane(Widget):
@@ -40,12 +41,16 @@ class AccountsPane(Widget):
 
     def compose(self) -> ComposeResult:
         """Create the pane layout."""
-        with Horizontal(classes="filter-bar"):
-            yield Input(
-                placeholder="Filter by account name...",
-                id="acc-filter-input",
-                disabled=True,
-            )
+        with PaneToolbar():
+            with Horizontal(id="accounts-toolbar-content"):
+                yield Static("Accounts", id="accounts-title")
+
+            with Horizontal(classes="filter-bar"):
+                yield Input(
+                    placeholder="Filter by account name...",
+                    id="acc-filter-input",
+                    disabled=True,
+                )
         yield DataTable(id="accounts-table")
 
     _ACCOUNTS_FIXED = {1: 20}
@@ -131,7 +136,8 @@ class AccountsPane(Widget):
         self.notify("Refreshed", timeout=2)
 
     def action_filter(self) -> None:
-        """Show/focus the filter input."""
+        """Show/focus the filter input and hide title."""
+        self.query_one("#accounts-toolbar-content").add_class("hidden")
         filter_bar = self.query_one(".filter-bar")
         filter_bar.add_class("visible")
         filter_input = self.query_one("#acc-filter-input", Input)
@@ -139,7 +145,7 @@ class AccountsPane(Widget):
         filter_input.focus()
 
     def action_dismiss_filter(self) -> None:
-        """Hide the filter input and clear the filter."""
+        """Hide the filter input, restore title, and clear the filter."""
         filter_bar = self.query_one(".filter-bar")
         if filter_bar.has_class("visible"):
             filter_bar.remove_class("visible")
@@ -147,6 +153,7 @@ class AccountsPane(Widget):
             filter_input.value = ""
             filter_input.disabled = True
             self.filter_text = ""
+            self.query_one("#accounts-toolbar-content").remove_class("hidden")
             self._update_table()
             self.query_one("#accounts-table", DataTable).focus()
 

--- a/src/hledger_textual/widgets/recurring_pane.py
+++ b/src/hledger_textual/widgets/recurring_pane.py
@@ -1,0 +1,389 @@
+"""Recurring transactions pane widget with CRUD, generation, and filtering."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from textual import on, work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.widget import Widget
+from textual.widgets import DataTable, Input, Static
+
+from hledger_textual.journal import JournalError, append_transaction
+from hledger_textual.recurring import (
+    RecurringError,
+    add_recurring_rule,
+    delete_recurring_rule,
+    ensure_recurring_file,
+    parse_recurring_rules,
+    update_last_generated,
+    update_recurring_rule,
+)
+from hledger_textual.recurring_engine import (
+    build_transaction_from_rule,
+    compute_next_due_date,
+    find_pending_generations,
+)
+from hledger_textual.models import RecurringRule
+from hledger_textual.widgets import distribute_column_widths
+from hledger_textual.widgets.pane_toolbar import PaneToolbar
+
+
+class RecurringPane(Widget):
+    """Widget showing recurring transaction rules with generation support."""
+
+    BINDINGS = [
+        Binding("a", "add", "Add", show=True, priority=True),
+        Binding("e", "edit", "Edit", show=True, priority=True),
+        Binding("enter", "edit", "Edit", show=False),
+        Binding("d", "delete", "Delete", show=True, priority=True),
+        Binding("g", "generate", "Generate", show=True, priority=True),
+        Binding("slash", "filter", "Filter", show=True, priority=True),
+        Binding("r", "refresh", "Refresh", show=True, priority=True),
+        Binding("escape", "dismiss_filter", "Dismiss filter", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+    ]
+
+    def __init__(self, journal_file: Path, **kwargs) -> None:
+        """Initialize the pane.
+
+        Args:
+            journal_file: Path to the hledger journal file.
+        """
+        super().__init__(**kwargs)
+        self.journal_file = journal_file
+        self._recurring_path: Path | None = None
+        self._rules: list[RecurringRule] = []
+        self.filter_text: str = ""
+
+    def compose(self) -> ComposeResult:
+        """Create the pane layout."""
+        with PaneToolbar():
+            with Horizontal(id="recurring-toolbar-content"):
+                yield Static("Recurring Transactions", id="recurring-title")
+
+            with Horizontal(classes="filter-bar"):
+                yield Input(
+                    placeholder="Filter by description...",
+                    id="recurring-filter-input",
+                    disabled=True,
+                )
+
+        yield DataTable(id="recurring-table")
+
+    _RECURRING_FIXED = {1: 16, 2: 14, 3: 14, 4: 12}
+
+    def on_mount(self) -> None:
+        """Set up the DataTable and load data."""
+        table = self.query_one("#recurring-table", DataTable)
+        table.cursor_type = "row"
+        table.add_column("Description", width=20)
+        table.add_column("Period", width=self._RECURRING_FIXED[1])
+        table.add_column("Next Due", width=self._RECURRING_FIXED[2])
+        table.add_column("Last Gen", width=self._RECURRING_FIXED[3])
+        table.add_column("Status", width=self._RECURRING_FIXED[4])
+        self._load_recurring_data()
+        table.focus()
+
+    def on_show(self) -> None:
+        """Restore focus to the table when the pane becomes visible."""
+        self.query_one("#recurring-table", DataTable).focus()
+
+    def on_resize(self) -> None:
+        """Recalculate column widths when the pane is resized."""
+        table = self.query_one("#recurring-table", DataTable)
+        distribute_column_widths(table, self._RECURRING_FIXED)
+
+    @work(thread=True, exclusive=True)
+    def _load_recurring_data(self) -> None:
+        """Load recurring rules from file."""
+        try:
+            self._recurring_path = ensure_recurring_file(self.journal_file)
+            self._rules = parse_recurring_rules(self._recurring_path)
+        except RecurringError as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+            self._rules = []
+
+        self.app.call_from_thread(self._update_table)
+
+    def _update_table(self) -> None:
+        """Refresh the DataTable with current recurring rules."""
+        table = self.query_one("#recurring-table", DataTable)
+        table.clear()
+
+        if not self._rules:
+            table.add_row(
+                "No recurring rules defined. Press [a] to add one.",
+                "", "", "", "",
+            )
+            return
+
+        today = date.today()
+
+        for rule in self._rules:
+            if self.filter_text and self.filter_text.lower() not in rule.description.lower():
+                continue
+
+            # Compute next due date
+            next_due = compute_next_due_date(
+                rule.period_expr, rule.last_generated, reference_date=today
+            )
+
+            next_due_str = next_due.isoformat() if next_due else "-"
+            last_gen_str = rule.last_generated or "Never"
+
+            if next_due:
+                status_str = "[green]Pending[/green]"
+            else:
+                status_str = "[dim]Up to date[/dim]"
+
+            table.add_row(
+                rule.description,
+                rule.period_expr,
+                next_due_str,
+                last_gen_str,
+                status_str,
+                key=rule.rule_id,
+            )
+
+    def _get_selected_rule(self) -> RecurringRule | None:
+        """Return the RecurringRule for the currently highlighted row."""
+        table = self.query_one("#recurring-table", DataTable)
+        if table.row_count == 0:
+            return None
+
+        row_key, _ = table.coordinate_to_cell_key(table.cursor_coordinate)
+        rule_id = row_key.value if row_key else None
+        if not rule_id:
+            return None
+
+        for rule in self._rules:
+            if rule.rule_id == rule_id:
+                return rule
+        return None
+
+    # --- Actions ---
+
+    def action_add(self) -> None:
+        """Open the form to add a new recurring rule."""
+        from hledger_textual.screens.recurring_form import RecurringFormScreen
+
+        def on_save(result: RecurringRule | None) -> None:
+            if result is not None:
+                self._do_add(result)
+
+        self.app.push_screen(
+            RecurringFormScreen(journal_file=self.journal_file),
+            callback=on_save,
+        )
+
+    def action_edit(self) -> None:
+        """Open the form to edit the selected recurring rule."""
+        rule = self._get_selected_rule()
+        if not rule:
+            return
+
+        from hledger_textual.screens.recurring_form import RecurringFormScreen
+
+        old_rule_id = rule.rule_id
+
+        def on_save(result: RecurringRule | None) -> None:
+            if result is not None:
+                self._do_update(old_rule_id, result)
+
+        self.app.push_screen(
+            RecurringFormScreen(journal_file=self.journal_file, rule=rule),
+            callback=on_save,
+        )
+
+    def action_delete(self) -> None:
+        """Delete the selected recurring rule (with confirmation)."""
+        rule = self._get_selected_rule()
+        if not rule:
+            return
+
+        from hledger_textual.screens.recurring_delete_confirm import RecurringDeleteConfirmModal
+
+        def on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self._do_delete(rule.rule_id)
+
+        self.app.push_screen(
+            RecurringDeleteConfirmModal(rule),
+            callback=on_confirm,
+        )
+
+    def action_generate(self) -> None:
+        """Generate pending recurring transactions."""
+        self._check_and_generate()
+
+    def action_refresh(self) -> None:
+        """Reload recurring data."""
+        self._load_recurring_data()
+        self.notify("Refreshed", timeout=2)
+
+    def action_filter(self) -> None:
+        """Show/focus the filter input."""
+        self.query_one("#recurring-toolbar-content").add_class("hidden")
+        filter_bar = self.query_one(".filter-bar")
+        filter_bar.add_class("visible")
+        filter_input = self.query_one("#recurring-filter-input", Input)
+        filter_input.disabled = False
+        filter_input.focus()
+
+    def action_dismiss_filter(self) -> None:
+        """Hide the filter input and clear the filter."""
+        filter_bar = self.query_one(".filter-bar")
+        if filter_bar.has_class("visible"):
+            filter_bar.remove_class("visible")
+            filter_input = self.query_one("#recurring-filter-input", Input)
+            filter_input.value = ""
+            filter_input.disabled = True
+            self.filter_text = ""
+            self.query_one("#recurring-toolbar-content").remove_class("hidden")
+            self._update_table()
+            self.query_one("#recurring-table", DataTable).focus()
+
+    def action_cursor_down(self) -> None:
+        """Move cursor down in the table."""
+        self.query_one("#recurring-table", DataTable).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        """Move cursor up in the table."""
+        self.query_one("#recurring-table", DataTable).action_cursor_up()
+
+    # --- Event handlers ---
+
+    @on(Input.Changed, "#recurring-filter-input")
+    def on_filter_changed(self, event: Input.Changed) -> None:
+        """Filter recurring rules as the user types."""
+        self.filter_text = event.value
+        self._update_table()
+
+    # --- Generation flow ---
+
+    @work(thread=True)
+    def _check_and_generate(self) -> None:
+        """Check for pending generations and show confirmation dialog."""
+        if not self._recurring_path:
+            return
+
+        rules = parse_recurring_rules(self._recurring_path)
+        pending = find_pending_generations(rules)
+
+        if not pending:
+            self.app.call_from_thread(
+                self.notify, "All recurring transactions are up to date", timeout=3
+            )
+            return
+
+        self.app.call_from_thread(self._show_generate_dialog, pending)
+
+    def _show_generate_dialog(
+        self,
+        pending: list[tuple[RecurringRule, list]],
+    ) -> None:
+        """Show the generation confirmation dialog."""
+        from hledger_textual.screens.recurring_generate import RecurringGenerateScreen
+
+        def on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self._do_generate(pending)
+
+        self.app.push_screen(
+            RecurringGenerateScreen(pending),
+            callback=on_confirm,
+        )
+
+    @work(thread=True)
+    def _do_generate(
+        self,
+        pending: list[tuple[RecurringRule, list]],
+    ) -> None:
+        """Generate transactions and update last_generated dates."""
+        if not self._recurring_path:
+            return
+
+        generated_count = 0
+        try:
+            for rule, dates in pending:
+                for target_date in dates:
+                    txn = build_transaction_from_rule(rule, target_date)
+                    append_transaction(self.journal_file, txn)
+                    generated_count += 1
+
+                # Update last_generated to the latest date
+                latest = max(dates)
+                update_last_generated(
+                    self._recurring_path,
+                    rule.rule_id,
+                    latest.isoformat(),
+                    self.journal_file,
+                )
+
+            self.app.call_from_thread(self._reload)
+            self.app.call_from_thread(
+                self.notify,
+                f"Generated {generated_count} transaction{'s' if generated_count != 1 else ''}",
+                timeout=3,
+            )
+        except (RecurringError, JournalError) as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+
+    # --- Mutation helpers ---
+
+    @work(thread=True)
+    def _do_add(self, rule: RecurringRule) -> None:
+        """Add a recurring rule and reload."""
+        if not self._recurring_path:
+            return
+        try:
+            add_recurring_rule(self._recurring_path, rule, self.journal_file)
+            self.app.call_from_thread(self._reload)
+            self.app.call_from_thread(self.notify, "Recurring rule added", timeout=3)
+        except RecurringError as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+
+    @work(thread=True)
+    def _do_update(self, old_rule_id: str, new_rule: RecurringRule) -> None:
+        """Update a recurring rule and reload."""
+        if not self._recurring_path:
+            return
+        try:
+            update_recurring_rule(
+                self._recurring_path, old_rule_id, new_rule, self.journal_file
+            )
+            self.app.call_from_thread(self._reload)
+            self.app.call_from_thread(self.notify, "Recurring rule updated", timeout=3)
+        except RecurringError as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+
+    @work(thread=True)
+    def _do_delete(self, rule_id: str) -> None:
+        """Delete a recurring rule and reload."""
+        if not self._recurring_path:
+            return
+        try:
+            delete_recurring_rule(self._recurring_path, rule_id, self.journal_file)
+            self.app.call_from_thread(self._reload)
+            self.app.call_from_thread(self.notify, "Recurring rule deleted", timeout=3)
+        except RecurringError as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+
+    def _reload(self) -> None:
+        """Reload recurring data after a mutation."""
+        self._load_recurring_data()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from hledger_textual.models import (
     AmountStyle,
     BudgetRule,
     Posting,
+    RecurringRule,
     SourcePosition,
     Transaction,
     TransactionStatus,
@@ -133,4 +134,54 @@ def sample_budget_rule(euro_style: AmountStyle) -> BudgetRule:
     return BudgetRule(
         account="Expenses:Groceries",
         amount=Amount(commodity="€", quantity=Decimal("800.00"), style=euro_style),
+    )
+
+
+@pytest.fixture
+def sample_recurring_journal_path() -> Path:
+    """Path to the sample recurring journal fixture."""
+    return FIXTURES_DIR / "sample_recurring.journal"
+
+
+@pytest.fixture
+def tmp_recurring_journal(tmp_path: Path, sample_recurring_journal_path: Path) -> Path:
+    """A temporary copy of the sample recurring journal for mutation tests."""
+    dest = tmp_path / "recurring.journal"
+    shutil.copy2(sample_recurring_journal_path, dest)
+    return dest
+
+
+@pytest.fixture
+def tmp_journal_with_recurring(
+    tmp_path: Path, sample_journal_path: Path, sample_recurring_journal_path: Path
+) -> Path:
+    """A temporary journal with recurring.journal and include directive."""
+    journal_dest = tmp_path / "test.journal"
+    recurring_dest = tmp_path / "recurring.journal"
+
+    shutil.copy2(sample_journal_path, journal_dest)
+    shutil.copy2(sample_recurring_journal_path, recurring_dest)
+
+    # Add include directive to the journal
+    content = journal_dest.read_text()
+    journal_dest.write_text(f"include recurring.journal\n\n{content}")
+
+    return journal_dest
+
+
+@pytest.fixture
+def sample_recurring_rule(euro_style: AmountStyle) -> RecurringRule:
+    """A sample recurring rule for testing."""
+    return RecurringRule(
+        rule_id="rent-001",
+        period_expr="monthly",
+        description="Rent payment",
+        postings=[
+            Posting(
+                account="Expenses:Rent",
+                amounts=[Amount(commodity="€", quantity=Decimal("800.00"), style=euro_style)],
+            ),
+            Posting(account="Assets:Bank:Checking"),
+        ],
+        last_generated="2026-02-01",
     )

--- a/tests/fixtures/sample_recurring.journal
+++ b/tests/fixtures/sample_recurring.journal
@@ -1,0 +1,7 @@
+~ monthly  Rent payment  ; recurring-id:rent-001, last-generated:2026-02-01
+    Expenses:Rent                                   €800.00
+    Assets:Bank:Checking
+
+~ every 2 weeks  Grocery run  ; recurring-id:grocery-001
+    Expenses:Groceries                              €100.00
+    Assets:Bank:Checking

--- a/tests/test_accounts_pane.py
+++ b/tests/test_accounts_pane.py
@@ -46,7 +46,7 @@ class TestAccountsPane:
         """Pressing 2 switches to the accounts pane."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             from textual.widgets import ContentSwitcher
 
@@ -59,7 +59,7 @@ class TestAccountsPane:
         """Accounts table shows accounts when data exists."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             table = accounts_app.screen.query_one("#accounts-table")
             assert table.row_count > 0
@@ -68,7 +68,7 @@ class TestAccountsPane:
         """Pressing r refreshes the accounts list."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             table = accounts_app.screen.query_one("#accounts-table")
             count_before = table.row_count
@@ -84,7 +84,7 @@ class TestAccountsFilter:
         """Pressing / shows the filter input."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             await pilot.press("slash")
             await pilot.pause()
@@ -98,7 +98,7 @@ class TestAccountsFilter:
         """Typing in the filter narrows the account list."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             table = accounts_app.screen.query_one("#accounts-table")
             count_all = table.row_count
@@ -114,7 +114,7 @@ class TestAccountsFilter:
         """Pressing Escape hides the filter and restores all rows."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             table = accounts_app.screen.query_one("#accounts-table")
             count_all = table.row_count
@@ -135,7 +135,7 @@ class TestAccountDrillDown:
         """Pressing Enter on an account opens the drill-down screen."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             await pilot.press("enter")
             await pilot.pause()
@@ -151,7 +151,7 @@ class TestAccountDrillDown:
         """Pressing Escape on the drill-down screen goes back."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             await pilot.press("enter")
             await pilot.pause()
@@ -169,7 +169,7 @@ class TestAccountDrillDown:
         """Drill-down screen shows transactions for the selected account."""
         async with accounts_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("5")
+            await pilot.press("6")
             await pilot.pause()
             await pilot.press("enter")
             await pilot.pause(delay=1.0)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -308,7 +308,7 @@ class TestTabNavigation:
     """Tests for keyboard number shortcuts that switch sections."""
 
     async def test_number_keys_switch_sections(self, app: HledgerTuiApp):
-        """Pressing 1-6 switches to the corresponding section."""
+        """Pressing 1-7 switches to the corresponding section."""
         from textual.widgets import ContentSwitcher
 
         async with app.run_test() as pilot:
@@ -316,10 +316,11 @@ class TestTabNavigation:
             sections = [
                 ("1", "summary"),
                 ("2", "transactions"),
-                ("3", "budget"),
-                ("4", "reports"),
-                ("5", "accounts"),
-                ("6", "info"),
+                ("3", "recurring"),
+                ("4", "budget"),
+                ("5", "reports"),
+                ("6", "accounts"),
+                ("7", "info"),
             ]
             for key, expected in sections:
                 await pilot.press(key)
@@ -347,7 +348,7 @@ class TestTabNavigation:
         from textual.widgets import Static
 
         async with app.run_test() as pilot:
-            for key in ("1", "2", "3", "4", "5", "6"):
+            for key in ("1", "2", "3", "4", "5", "6", "7"):
                 await pilot.press(key)
                 await pilot.pause()
                 footer = app.screen.query_one("#footer-bar", Static)

--- a/tests/test_budget_pane.py
+++ b/tests/test_budget_pane.py
@@ -76,7 +76,7 @@ class TestBudgetTabSwitch:
         """Pressing 3 switches to the budget pane."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause()
             from textual.widgets import ContentSwitcher
             switcher = budget_app.screen.query_one("#content-switcher", ContentSwitcher)
@@ -86,7 +86,7 @@ class TestBudgetTabSwitch:
         """Budget table shows budget rules when data exists."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             table = budget_app.screen.query_one("#budget-table")
             # Should have 2 budget rules (Groceries and Restaurant)
@@ -100,7 +100,7 @@ class TestBudgetEmptyState:
         """Shows empty state message when no budget rules exist."""
         async with empty_budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             table = empty_budget_app.screen.query_one("#budget-table")
             # Should have 1 row with the empty state message
@@ -114,7 +114,7 @@ class TestBudgetAdd:
         """Pressing 'a' on budget pane opens the form."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("a")
             await pilot.pause()
@@ -125,7 +125,7 @@ class TestBudgetAdd:
         """Cancelling the add form does not add a rule."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("a")
             await pilot.pause()
@@ -142,7 +142,7 @@ class TestBudgetDelete:
         """Pressing 'd' shows delete confirmation."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("d")
             await pilot.pause()
@@ -153,7 +153,7 @@ class TestBudgetDelete:
         """Cancelling delete does not remove the rule."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("d")
             await pilot.pause()
@@ -168,7 +168,7 @@ class TestBudgetDelete:
         """Confirming delete removes the rule."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("d")
             await pilot.pause()
@@ -187,7 +187,7 @@ class TestBudgetFilter:
         """Pressing '/' shows the filter input."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("slash")
             await pilot.pause()
@@ -200,7 +200,7 @@ class TestBudgetFilter:
         """Pressing Escape hides the filter."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("slash")
             await pilot.pause()
@@ -215,7 +215,7 @@ class TestBudgetFilter:
         """Typing in the filter shows only matching rules."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("slash")
             await pilot.pause()
@@ -233,7 +233,7 @@ class TestBudgetEdit:
         """Pressing 'e' with a rule selected opens BudgetFormScreen in edit mode."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("e")
             await pilot.pause()
@@ -245,7 +245,7 @@ class TestBudgetEdit:
         """The edit form is pre-filled with the currently selected rule."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("e")
             await pilot.pause()
@@ -261,7 +261,7 @@ class TestBudgetEdit:
         """Cancelling the edit form does not modify any budget rule."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("e")
             await pilot.pause()
@@ -280,7 +280,7 @@ class TestBudgetMonthNavigation:
         from hledger_textual.widgets.budget_pane import BudgetPane
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
             initial = pane._current_month
@@ -293,7 +293,7 @@ class TestBudgetMonthNavigation:
         from hledger_textual.widgets.budget_pane import BudgetPane
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
             initial = pane._current_month
@@ -309,7 +309,7 @@ class TestBudgetMonthNavigation:
         from hledger_textual.widgets.budget_pane import BudgetPane
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
             pane._current_month = date(2026, 1, 1)
@@ -326,7 +326,7 @@ class TestBudgetMonthNavigation:
         from hledger_textual.widgets.budget_pane import BudgetPane
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
             pane._current_month = date(2025, 12, 1)
@@ -345,7 +345,7 @@ class TestBudgetTodayMonth:
 
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
 
@@ -365,7 +365,7 @@ class TestBudgetTodayMonth:
 
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
 
             # Navigate away
@@ -388,7 +388,7 @@ class TestBudgetRefresh:
         """Pressing 'r' reloads the data without changing the row count."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             count_before = budget_app.screen.query_one("#budget-table").row_count
             await pilot.press("r")
@@ -403,7 +403,7 @@ class TestBudgetFooter:
         """Footer shows budget-specific text when switching to budget tab."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause()
             from textual.widgets import Static
             footer = budget_app.screen.query_one("#footer-bar", Static)
@@ -419,7 +419,7 @@ class TestBudgetCursor:
         """Pressing 'j' moves the cursor down without crashing."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("j")
             await pilot.pause()
@@ -430,7 +430,7 @@ class TestBudgetCursor:
         """Pressing 'k' moves the cursor up without crashing."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("j")
             await pilot.pause()
@@ -451,7 +451,7 @@ class TestBudgetColorCoding:
 
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
             # Inject an over-budget row (actual > budget → red path)
@@ -476,7 +476,7 @@ class TestBudgetColorCoding:
 
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             pane = budget_app.screen.query_one(BudgetPane)
             # Inject a near-budget row (80% usage → yellow path)
@@ -503,7 +503,7 @@ class TestBudgetNoSelection:
         """Pressing 'e' with no rule selected does not push a form screen."""
         async with empty_budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("e")
             await pilot.pause()
@@ -516,7 +516,7 @@ class TestBudgetNoSelection:
         """Pressing 'd' with no rule selected does not push a confirm screen."""
         async with empty_budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("d")
             await pilot.pause()
@@ -533,7 +533,7 @@ class TestBudgetAddSave:
         """Saving the add form appends a new rule to the budget file."""
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("a")
             await pilot.pause()
@@ -559,7 +559,7 @@ class TestBudgetAddSave:
         monkeypatch.setattr("hledger_textual.widgets.budget_pane.add_budget_rule", _raise)
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("a")
             await pilot.pause()
@@ -584,7 +584,7 @@ class TestBudgetEditSave:
 
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("e")
             await pilot.pause()
@@ -608,7 +608,7 @@ class TestBudgetEditSave:
         monkeypatch.setattr("hledger_textual.widgets.budget_pane.update_budget_rule", _raise)
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("e")
             await pilot.pause()
@@ -635,7 +635,7 @@ class TestBudgetDeleteError:
         monkeypatch.setattr("hledger_textual.widgets.budget_pane.delete_budget_rule", _raise)
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("d")
             await pilot.pause()
@@ -662,7 +662,7 @@ class TestBudgetLoadErrors:
         )
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             # App must not crash
             assert budget_app.screen.query_one("#budget-table") is not None
@@ -681,7 +681,7 @@ class TestBudgetLoadErrors:
         )
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             assert budget_app.screen.query_one("#budget-table") is not None
 
@@ -701,7 +701,7 @@ class TestBudgetDefaultCommodity:
         )
         async with budget_app.run_test() as pilot:
             await pilot.pause()
-            await pilot.press("3")
+            await pilot.press("4")
             await pilot.pause(delay=1.0)
             await pilot.press("a")
             await pilot.pause()

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -1,0 +1,344 @@
+"""Tests for recurring transaction file management."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from hledger_textual.models import (
+    Amount,
+    AmountStyle,
+    Posting,
+    RecurringRule,
+    TransactionStatus,
+)
+from hledger_textual.recurring import (
+    RecurringError,
+    _format_recurring_file,
+    _parse_amount_string,
+    ensure_recurring_file,
+    generate_rule_id,
+    parse_recurring_rules,
+)
+from tests.conftest import has_hledger
+
+
+class TestParseAmountString:
+    """Tests for _parse_amount_string."""
+
+    def test_left_commodity(self):
+        """Parse amount with left-side commodity."""
+        qty, commodity = _parse_amount_string("€800.00")
+        assert qty == Decimal("800.00")
+        assert commodity == "€"
+
+    def test_right_commodity(self):
+        """Parse amount with right-side commodity."""
+        qty, commodity = _parse_amount_string("800.00EUR")
+        assert qty == Decimal("800.00")
+        assert commodity == "EUR"
+
+    def test_empty_raises(self):
+        """Empty string raises RecurringError."""
+        with pytest.raises(RecurringError):
+            _parse_amount_string("")
+
+    def test_invalid_raises(self):
+        """Unparseable string raises RecurringError."""
+        with pytest.raises(RecurringError):
+            _parse_amount_string("abc")
+
+
+class TestParseRecurringRules:
+    """Tests for parse_recurring_rules."""
+
+    def test_parse_sample(self, sample_recurring_journal_path: Path):
+        """Parse rules from sample recurring journal."""
+        rules = parse_recurring_rules(sample_recurring_journal_path)
+        assert len(rules) == 2
+
+        assert rules[0].rule_id == "rent-001"
+        assert rules[0].period_expr == "monthly"
+        assert rules[0].description == "Rent payment"
+        assert rules[0].last_generated == "2026-02-01"
+        assert len(rules[0].postings) == 2
+        assert rules[0].postings[0].account == "Expenses:Rent"
+        assert rules[0].postings[0].amounts[0].quantity == Decimal("800.00")
+        assert rules[0].postings[1].account == "Assets:Bank:Checking"
+        assert rules[0].postings[1].amounts == []
+
+        assert rules[1].rule_id == "grocery-001"
+        assert rules[1].period_expr == "every 2 weeks"
+        assert rules[1].description == "Grocery run"
+        assert rules[1].last_generated is None
+        assert len(rules[1].postings) == 2
+
+    def test_parse_empty_file(self, tmp_path: Path):
+        """Parse empty file returns empty list."""
+        recurring_file = tmp_path / "empty.journal"
+        recurring_file.write_text("")
+        assert parse_recurring_rules(recurring_file) == []
+
+    def test_parse_nonexistent(self, tmp_path: Path):
+        """Nonexistent file returns empty list."""
+        assert parse_recurring_rules(tmp_path / "nope.journal") == []
+
+    def test_parse_with_status(self, tmp_path: Path):
+        """Parse rule with cleared status."""
+        recurring_file = tmp_path / "status.journal"
+        recurring_file.write_text(
+            "~ monthly  * Cleared rent  ; recurring-id:r-001\n"
+            "    Expenses:Rent                                   €800.00\n"
+            "    Assets:Bank:Checking\n"
+        )
+        rules = parse_recurring_rules(recurring_file)
+        assert len(rules) == 1
+        assert rules[0].status == TransactionStatus.CLEARED
+        assert rules[0].description == "Cleared rent"
+
+    def test_parse_with_code(self, tmp_path: Path):
+        """Parse rule with code."""
+        recurring_file = tmp_path / "code.journal"
+        recurring_file.write_text(
+            "~ monthly  (INV-001) Rent  ; recurring-id:r-002\n"
+            "    Expenses:Rent                                   €800.00\n"
+            "    Assets:Bank:Checking\n"
+        )
+        rules = parse_recurring_rules(recurring_file)
+        assert len(rules) == 1
+        assert rules[0].code == "INV-001"
+        assert rules[0].description == "Rent"
+
+
+class TestEnsureRecurringFile:
+    """Tests for ensure_recurring_file."""
+
+    def test_creates_recurring_file(self, tmp_path: Path):
+        """Creates recurring.journal if missing."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("; some journal\n")
+
+        recurring_path = ensure_recurring_file(journal)
+        assert recurring_path.exists()
+        assert recurring_path.name == "recurring.journal"
+
+    def test_adds_include_directive(self, tmp_path: Path):
+        """Adds include directive to main journal."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("; some journal\n")
+
+        ensure_recurring_file(journal)
+        content = journal.read_text()
+        assert "include recurring.journal" in content
+
+    def test_does_not_duplicate_include(self, tmp_path: Path):
+        """Does not add include directive if already present."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("include recurring.journal\n\n; some journal\n")
+        recurring = tmp_path / "recurring.journal"
+        recurring.write_text("")
+
+        ensure_recurring_file(journal)
+        content = journal.read_text()
+        assert content.count("include recurring.journal") == 1
+
+    def test_idempotent(self, tmp_path: Path):
+        """Calling twice is safe."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("; some journal\n")
+
+        ensure_recurring_file(journal)
+        ensure_recurring_file(journal)
+
+        content = journal.read_text()
+        assert content.count("include recurring.journal") == 1
+
+
+class TestFormatRecurringFile:
+    """Tests for _format_recurring_file."""
+
+    def test_empty_rules(self):
+        """Empty rules list produces empty content."""
+        assert _format_recurring_file([]) == ""
+
+    def test_format_rules(self, euro_style: AmountStyle):
+        """Formats rules as periodic transactions."""
+        rules = [
+            RecurringRule(
+                rule_id="rent-001",
+                period_expr="monthly",
+                description="Rent payment",
+                postings=[
+                    Posting(
+                        account="Expenses:Rent",
+                        amounts=[Amount(commodity="€", quantity=Decimal("800.00"), style=euro_style)],
+                    ),
+                    Posting(account="Assets:Bank:Checking"),
+                ],
+                last_generated="2026-02-01",
+            ),
+        ]
+        content = _format_recurring_file(rules)
+        assert "~ monthly" in content
+        assert "Rent payment" in content
+        assert "recurring-id:rent-001" in content
+        assert "last-generated:2026-02-01" in content
+        assert "€800.00" in content
+        assert "Assets:Bank:Checking" in content
+
+    def test_roundtrip(self, sample_recurring_journal_path: Path):
+        """Parse then format produces valid content that can be re-parsed."""
+        rules = parse_recurring_rules(sample_recurring_journal_path)
+        content = _format_recurring_file(rules)
+        tmp_path = sample_recurring_journal_path.parent / "roundtrip_recurring.journal"
+        try:
+            tmp_path.write_text(content)
+            reparsed = parse_recurring_rules(tmp_path)
+            assert len(reparsed) == len(rules)
+            for orig, rt in zip(rules, reparsed):
+                assert orig.rule_id == rt.rule_id
+                assert orig.period_expr == rt.period_expr
+                assert orig.description == rt.description
+                assert orig.last_generated == rt.last_generated
+                assert len(orig.postings) == len(rt.postings)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+
+class TestGenerateRuleId:
+    """Tests for generate_rule_id."""
+
+    def test_generates_slug(self):
+        """Generates a slug-based ID."""
+        rule_id = generate_rule_id("Rent payment")
+        assert rule_id.startswith("rent-payment-")
+        assert len(rule_id) > len("rent-payment-")
+
+    def test_unique(self):
+        """Multiple calls produce different IDs."""
+        ids = {generate_rule_id("Test") for _ in range(10)}
+        assert len(ids) == 10
+
+    def test_empty_description(self):
+        """Empty description produces valid ID."""
+        rule_id = generate_rule_id("")
+        assert rule_id.startswith("rule-")
+
+
+@pytest.mark.skipif(not has_hledger(), reason="hledger not installed")
+class TestRecurringCRUD:
+    """Integration tests for recurring CRUD operations (require hledger)."""
+
+    def test_add_rule(self, tmp_journal_with_recurring: Path):
+        """Add a recurring rule."""
+        from hledger_textual.recurring import add_recurring_rule
+
+        recurring_path = tmp_journal_with_recurring.parent / "recurring.journal"
+        new_rule = RecurringRule(
+            rule_id="transport-001",
+            period_expr="monthly",
+            description="Train pass",
+            postings=[
+                Posting(
+                    account="Expenses:Transport",
+                    amounts=[
+                        Amount(
+                            commodity="€",
+                            quantity=Decimal("100.00"),
+                            style=AmountStyle(commodity_side="L", commodity_spaced=False, precision=2),
+                        )
+                    ],
+                ),
+                Posting(account="Assets:Bank:Checking"),
+            ],
+        )
+        add_recurring_rule(recurring_path, new_rule, tmp_journal_with_recurring)
+        rules = parse_recurring_rules(recurring_path)
+        rule_ids = [r.rule_id for r in rules]
+        assert "transport-001" in rule_ids
+
+    def test_add_duplicate_raises(self, tmp_journal_with_recurring: Path):
+        """Adding a duplicate rule_id raises RecurringError."""
+        from hledger_textual.recurring import add_recurring_rule
+
+        recurring_path = tmp_journal_with_recurring.parent / "recurring.journal"
+        dup_rule = RecurringRule(
+            rule_id="rent-001",
+            period_expr="weekly",
+            description="Duplicate",
+            postings=[
+                Posting(
+                    account="Expenses:Other",
+                    amounts=[
+                        Amount(
+                            commodity="€",
+                            quantity=Decimal("50.00"),
+                            style=AmountStyle(commodity_side="L", commodity_spaced=False, precision=2),
+                        )
+                    ],
+                ),
+                Posting(account="Assets:Bank:Checking"),
+            ],
+        )
+        with pytest.raises(RecurringError, match="already exists"):
+            add_recurring_rule(recurring_path, dup_rule, tmp_journal_with_recurring)
+
+    def test_update_rule(self, tmp_journal_with_recurring: Path):
+        """Update an existing recurring rule."""
+        from hledger_textual.recurring import update_recurring_rule
+
+        recurring_path = tmp_journal_with_recurring.parent / "recurring.journal"
+        new_rule = RecurringRule(
+            rule_id="rent-001",
+            period_expr="monthly",
+            description="Updated rent",
+            postings=[
+                Posting(
+                    account="Expenses:Rent",
+                    amounts=[
+                        Amount(
+                            commodity="€",
+                            quantity=Decimal("900.00"),
+                            style=AmountStyle(commodity_side="L", commodity_spaced=False, precision=2),
+                        )
+                    ],
+                ),
+                Posting(account="Assets:Bank:Checking"),
+            ],
+            last_generated="2026-02-01",
+        )
+        update_recurring_rule(recurring_path, "rent-001", new_rule, tmp_journal_with_recurring)
+        rules = parse_recurring_rules(recurring_path)
+        rent_rule = next(r for r in rules if r.rule_id == "rent-001")
+        assert rent_rule.description == "Updated rent"
+        assert rent_rule.postings[0].amounts[0].quantity == Decimal("900.00")
+
+    def test_delete_rule(self, tmp_journal_with_recurring: Path):
+        """Delete a recurring rule."""
+        from hledger_textual.recurring import delete_recurring_rule
+
+        recurring_path = tmp_journal_with_recurring.parent / "recurring.journal"
+        delete_recurring_rule(recurring_path, "grocery-001", tmp_journal_with_recurring)
+        rules = parse_recurring_rules(recurring_path)
+        rule_ids = [r.rule_id for r in rules]
+        assert "grocery-001" not in rule_ids
+
+    def test_delete_nonexistent_raises(self, tmp_journal_with_recurring: Path):
+        """Deleting a nonexistent rule raises RecurringError."""
+        from hledger_textual.recurring import delete_recurring_rule
+
+        recurring_path = tmp_journal_with_recurring.parent / "recurring.journal"
+        with pytest.raises(RecurringError, match="No recurring rule found"):
+            delete_recurring_rule(recurring_path, "nope-999", tmp_journal_with_recurring)
+
+    def test_update_last_generated(self, tmp_journal_with_recurring: Path):
+        """Update last_generated date for a rule."""
+        from hledger_textual.recurring import update_last_generated
+
+        recurring_path = tmp_journal_with_recurring.parent / "recurring.journal"
+        update_last_generated(recurring_path, "rent-001", "2026-03-01", tmp_journal_with_recurring)
+        rules = parse_recurring_rules(recurring_path)
+        rent_rule = next(r for r in rules if r.rule_id == "rent-001")
+        assert rent_rule.last_generated == "2026-03-01"

--- a/tests/test_recurring_engine.py
+++ b/tests/test_recurring_engine.py
@@ -1,0 +1,385 @@
+"""Tests for the recurring transaction engine."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from hledger_textual.models import (
+    Amount,
+    AmountStyle,
+    Posting,
+    RecurringRule,
+    TransactionStatus,
+)
+from hledger_textual.recurring_engine import (
+    build_transaction_from_rule,
+    compute_all_due_dates,
+    compute_next_due_date,
+    find_pending_generations,
+    validate_period_expression,
+)
+from tests.conftest import has_hledger
+
+pytestmark = pytest.mark.skipif(not has_hledger(), reason="hledger not installed")
+
+
+class TestValidatePeriodExpression:
+    """Tests for validate_period_expression."""
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "daily",
+            "weekly",
+            "every 2 weeks",
+            "biweekly",
+            "monthly",
+            "bimonthly",
+            "quarterly",
+            "yearly",
+            "every 3 days",
+            "every 6 months",
+            "every 2 years",
+        ],
+    )
+    def test_valid_expressions(self, expr: str):
+        """Known period expressions are valid."""
+        is_valid, error = validate_period_expression(expr)
+        assert is_valid is True
+        assert error == ""
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "every 3rd thursday",
+            "every friday",
+            "every 2nd monday",
+            "every feb 14th",
+        ],
+    )
+    def test_valid_complex_expressions(self, expr: str):
+        """Complex hledger period expressions are valid."""
+        is_valid, error = validate_period_expression(expr)
+        assert is_valid is True
+        assert error == ""
+
+    @pytest.mark.parametrize(
+        "expr",
+        ["never", "sometimes", "every other day", ""],
+    )
+    def test_invalid_expressions(self, expr: str):
+        """Unknown period expressions are invalid."""
+        is_valid, error = validate_period_expression(expr)
+        assert is_valid is False
+        assert error != ""
+
+    def test_invalid_expression_has_descriptive_error(self):
+        """Invalid expressions return a descriptive error message."""
+        is_valid, error = validate_period_expression("nonsense garbage")
+        assert is_valid is False
+        assert "unexpected" in error.lower() or len(error) > 0
+
+
+class TestComputeNextDueDate:
+    """Tests for compute_next_due_date."""
+
+    def test_monthly_due(self):
+        """Monthly rule with last_generated in Feb is due in March."""
+        result = compute_next_due_date(
+            "monthly",
+            "2026-02-01",
+            reference_date=date(2026, 3, 2),
+        )
+        assert result == date(2026, 3, 1)
+
+    def test_monthly_not_due(self):
+        """Monthly rule generated today is not due again."""
+        result = compute_next_due_date(
+            "monthly",
+            "2026-03-01",
+            reference_date=date(2026, 3, 2),
+        )
+        assert result is None
+
+    def test_weekly(self):
+        """Weekly rule due after 7 days."""
+        result = compute_next_due_date(
+            "weekly",
+            "2026-02-20",
+            reference_date=date(2026, 3, 2),
+        )
+        assert result == date(2026, 2, 27)
+
+    def test_daily(self):
+        """Daily rule is due next day."""
+        result = compute_next_due_date(
+            "daily",
+            "2026-03-01",
+            reference_date=date(2026, 3, 2),
+        )
+        assert result == date(2026, 3, 2)
+
+    def test_biweekly(self):
+        """Every 2 weeks rule."""
+        result = compute_next_due_date(
+            "every 2 weeks",
+            "2026-02-15",
+            reference_date=date(2026, 3, 2),
+        )
+        assert result == date(2026, 3, 1)
+
+    def test_quarterly(self):
+        """Quarterly rule."""
+        result = compute_next_due_date(
+            "quarterly",
+            "2026-01-01",
+            reference_date=date(2026, 4, 1),
+        )
+        assert result == date(2026, 4, 1)
+
+    def test_yearly(self):
+        """Yearly rule."""
+        result = compute_next_due_date(
+            "yearly",
+            "2025-03-01",
+            reference_date=date(2026, 3, 2),
+        )
+        assert result == date(2026, 3, 1)
+
+    def test_no_last_generated(self):
+        """When last_generated is None, generates from 1st of current month."""
+        result = compute_next_due_date(
+            "monthly",
+            None,
+            reference_date=date(2026, 3, 15),
+        )
+        # hledger generates from 1st of the month; monthly lands on Mar 1
+        assert result == date(2026, 3, 1)
+
+    def test_no_last_generated_daily(self):
+        """Daily rule with no last_generated is immediately due."""
+        result = compute_next_due_date(
+            "daily",
+            None,
+            reference_date=date(2026, 3, 15),
+        )
+        # hledger generates daily from Mar 1; first date is Mar 1
+        assert result == date(2026, 3, 1)
+
+    def test_every_n_days(self):
+        """Every 3 days rule."""
+        result = compute_next_due_date(
+            "every 3 days",
+            "2026-03-01",
+            reference_date=date(2026, 3, 5),
+        )
+        assert result == date(2026, 3, 4)
+
+    def test_every_n_months(self):
+        """Every 2 months rule."""
+        result = compute_next_due_date(
+            "every 2 months",
+            "2026-01-15",
+            reference_date=date(2026, 3, 20),
+        )
+        assert result == date(2026, 3, 15)
+
+    def test_every_3rd_thursday(self):
+        """Every 3rd thursday rule (complex hledger expression)."""
+        result = compute_next_due_date(
+            "every 3rd thursday",
+            "2026-02-19",
+            reference_date=date(2026, 3, 20),
+        )
+        assert result == date(2026, 3, 19)
+
+    def test_every_friday(self):
+        """Every friday rule."""
+        result = compute_next_due_date(
+            "every friday",
+            "2026-02-27",
+            reference_date=date(2026, 3, 10),
+        )
+        assert result == date(2026, 3, 6)
+
+
+class TestComputeAllDueDates:
+    """Tests for compute_all_due_dates."""
+
+    def test_single_due(self):
+        """One monthly occurrence due."""
+        dates = compute_all_due_dates(
+            "monthly",
+            "2026-02-01",
+            up_to=date(2026, 3, 2),
+        )
+        assert dates == [date(2026, 3, 1)]
+
+    def test_multiple_due(self):
+        """Multiple monthly occurrences when app was not opened."""
+        dates = compute_all_due_dates(
+            "monthly",
+            "2025-12-01",
+            up_to=date(2026, 3, 2),
+        )
+        assert dates == [
+            date(2026, 1, 1),
+            date(2026, 2, 1),
+            date(2026, 3, 1),
+        ]
+
+    def test_none_due(self):
+        """No occurrences due when recently generated."""
+        dates = compute_all_due_dates(
+            "monthly",
+            "2026-03-01",
+            up_to=date(2026, 3, 2),
+        )
+        assert dates == []
+
+    def test_weekly_multiple(self):
+        """Multiple weekly occurrences."""
+        dates = compute_all_due_dates(
+            "weekly",
+            "2026-02-15",
+            up_to=date(2026, 3, 2),
+        )
+        assert dates == [
+            date(2026, 2, 22),
+            date(2026, 3, 1),
+        ]
+
+    def test_no_last_generated(self):
+        """No last_generated with monthly rule generates from 1st of month."""
+        dates = compute_all_due_dates(
+            "monthly",
+            None,
+            up_to=date(2026, 3, 2),
+        )
+        # hledger generates from 1st of the up_to month; monthly on Mar 1
+        assert dates == [date(2026, 3, 1)]
+
+    def test_every_3rd_thursday_multiple(self):
+        """Multiple 3rd Thursday occurrences."""
+        dates = compute_all_due_dates(
+            "every 3rd thursday",
+            "2026-02-19",
+            up_to=date(2026, 4, 20),
+        )
+        assert dates == [
+            date(2026, 3, 19),
+            date(2026, 4, 16),
+        ]
+
+    def test_every_friday_multiple(self):
+        """Multiple Friday occurrences."""
+        dates = compute_all_due_dates(
+            "every friday",
+            "2026-02-27",
+            up_to=date(2026, 3, 14),
+        )
+        assert dates == [
+            date(2026, 3, 6),
+            date(2026, 3, 13),
+        ]
+
+
+class TestFindPendingGenerations:
+    """Tests for find_pending_generations."""
+
+    def test_mix_pending_and_uptodate(self):
+        """Finds rules with pending dates and skips up-to-date ones."""
+        style = AmountStyle(commodity_side="L", commodity_spaced=False, precision=2)
+        rules = [
+            RecurringRule(
+                rule_id="r1",
+                period_expr="monthly",
+                description="Rule 1",
+                postings=[
+                    Posting(
+                        account="Expenses:A",
+                        amounts=[Amount(commodity="€", quantity=Decimal("100.00"), style=style)],
+                    ),
+                    Posting(account="Assets:Bank"),
+                ],
+                last_generated="2026-02-01",
+            ),
+            RecurringRule(
+                rule_id="r2",
+                period_expr="monthly",
+                description="Rule 2",
+                postings=[
+                    Posting(
+                        account="Expenses:B",
+                        amounts=[Amount(commodity="€", quantity=Decimal("200.00"), style=style)],
+                    ),
+                    Posting(account="Assets:Bank"),
+                ],
+                last_generated="2026-03-01",
+            ),
+        ]
+        pending = find_pending_generations(rules, up_to=date(2026, 3, 2))
+        assert len(pending) == 1
+        assert pending[0][0].rule_id == "r1"
+        assert pending[0][1] == [date(2026, 3, 1)]
+
+    def test_all_uptodate(self):
+        """No pending when all rules are up to date."""
+        rules = [
+            RecurringRule(
+                rule_id="r1",
+                period_expr="monthly",
+                description="Rule 1",
+                last_generated="2026-03-01",
+            ),
+        ]
+        pending = find_pending_generations(rules, up_to=date(2026, 3, 2))
+        assert pending == []
+
+
+class TestBuildTransactionFromRule:
+    """Tests for build_transaction_from_rule."""
+
+    def test_basic_build(self):
+        """Build a transaction from a rule."""
+        style = AmountStyle(commodity_side="L", commodity_spaced=False, precision=2)
+        rule = RecurringRule(
+            rule_id="rent-001",
+            period_expr="monthly",
+            description="Rent payment",
+            postings=[
+                Posting(
+                    account="Expenses:Rent",
+                    amounts=[Amount(commodity="€", quantity=Decimal("800.00"), style=style)],
+                ),
+                Posting(account="Assets:Bank:Checking"),
+            ],
+            status=TransactionStatus.CLEARED,
+        )
+        txn = build_transaction_from_rule(rule, date(2026, 3, 1))
+
+        assert txn.date == "2026-03-01"
+        assert txn.description == "Rent payment"
+        assert txn.status == TransactionStatus.CLEARED
+        assert "recurring-id:rent-001" in txn.comment
+        assert "recurring-date:2026-03-01" in txn.comment
+        assert len(txn.postings) == 2
+        assert txn.postings[0].account == "Expenses:Rent"
+        assert txn.postings[0].amounts[0].quantity == Decimal("800.00")
+        assert txn.postings[1].account == "Assets:Bank:Checking"
+        assert txn.postings[1].amounts == []
+
+    def test_with_user_comment(self):
+        """Rule comment is preserved in generated transaction."""
+        rule = RecurringRule(
+            rule_id="test-001",
+            period_expr="monthly",
+            description="Test",
+            comment="auto-pay",
+        )
+        txn = build_transaction_from_rule(rule, date(2026, 3, 1))
+        assert "auto-pay" in txn.comment
+        assert "recurring-id:test-001" in txn.comment

--- a/tests/test_recurring_form.py
+++ b/tests/test_recurring_form.py
@@ -1,0 +1,233 @@
+"""Tests for the RecurringFormScreen modal (save logic, validation, buttons)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from textual.app import App, ComposeResult
+from textual.widgets import Input, Select, Static
+
+from hledger_textual.models import (
+    Amount,
+    AmountStyle,
+    Posting,
+    RecurringRule,
+    TransactionStatus,
+)
+from hledger_textual.screens.recurring_form import RecurringFormScreen
+from tests.conftest import has_hledger
+
+
+class _FormApp(App):
+    """Minimal app that opens a RecurringFormScreen modal for isolated testing."""
+
+    def __init__(self, journal_file: Path, rule: RecurringRule | None = None) -> None:
+        """Initialize with a journal file path and optional rule for edit mode."""
+        super().__init__()
+        self._journal_file = journal_file
+        self._rule = rule
+        self.results: list[RecurringRule | None] = []
+
+    def compose(self) -> ComposeResult:
+        """Compose a placeholder widget under the modal."""
+        yield Static("test")
+
+    def on_mount(self) -> None:
+        """Push the form modal immediately on mount."""
+        self.push_screen(
+            RecurringFormScreen(self._journal_file, rule=self._rule),
+            callback=self.results.append,
+        )
+
+
+class TestRecurringFormSave:
+    """Tests for valid and invalid form submissions."""
+
+    async def test_valid_form_dismisses_with_rule(self, tmp_path: Path):
+        """Saving with valid data dismisses the modal with a RecurringRule."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            # Period defaults to "monthly"
+            form.query_one("#recurring-input-description", Input).value = "Rent"
+            # Add accounts to posting rows
+            from hledger_textual.widgets.posting_row import PostingRow
+            rows = list(form.query_one("#recurring-postings-container").query(PostingRow))
+            rows[0].query_one(f"#account-0", Input).value = "Expenses:Rent"
+            rows[0].query_one(f"#amount-0", Input).value = "800.00"
+            rows[1].query_one(f"#account-1", Input).value = "Assets:Bank"
+            form._save()
+            await pilot.pause()
+            assert len(app.results) == 1
+            rule = app.results[0]
+            assert isinstance(rule, RecurringRule)
+            assert rule.description == "Rent"
+            assert rule.period_expr == "monthly"
+            assert len(rule.postings) == 2
+
+    async def test_empty_description_rejected(self, tmp_path: Path):
+        """Empty description keeps the form open."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            form.query_one("#recurring-input-description", Input).value = ""
+            form._save()
+            await pilot.pause()
+            assert isinstance(app.screen, RecurringFormScreen)
+            assert app.results == []
+
+    async def test_insufficient_postings_rejected(self, tmp_path: Path):
+        """Less than 2 postings with accounts keeps the form open."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            form.query_one("#recurring-input-description", Input).value = "Test"
+            # Only fill one posting
+            from hledger_textual.widgets.posting_row import PostingRow
+            rows = list(form.query_one("#recurring-postings-container").query(PostingRow))
+            rows[0].query_one(f"#account-0", Input).value = "Expenses:Rent"
+            rows[0].query_one(f"#amount-0", Input).value = "800.00"
+            # Leave second posting empty
+            form._save()
+            await pilot.pause()
+            assert isinstance(app.screen, RecurringFormScreen)
+            assert app.results == []
+
+    async def test_cancel_button_dismisses_with_none(self, tmp_path: Path):
+        """Clicking Cancel dismisses the modal with None."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.click(app.screen.query_one("#btn-recurring-cancel"))
+            await pilot.pause()
+            assert app.results == [None]
+
+    async def test_escape_key_dismisses_with_none(self, tmp_path: Path):
+        """Pressing Escape dismisses the modal with None."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.results == [None]
+
+
+class TestRecurringFormEditMode:
+    """Tests for RecurringFormScreen in edit mode."""
+
+    @pytest.fixture
+    def sample_rule(self) -> RecurringRule:
+        """A sample RecurringRule for edit-mode testing."""
+        style = AmountStyle(commodity_side="L", commodity_spaced=False, precision=2)
+        return RecurringRule(
+            rule_id="rent-001",
+            period_expr="monthly",
+            description="Rent payment",
+            postings=[
+                Posting(
+                    account="Expenses:Rent",
+                    amounts=[Amount(commodity="€", quantity=Decimal("800.00"), style=style)],
+                ),
+                Posting(account="Assets:Bank:Checking"),
+            ],
+            last_generated="2026-02-01",
+        )
+
+    async def test_edit_form_is_detected_as_edit(self, tmp_path: Path, sample_rule):
+        """is_edit property is True when a rule is provided."""
+        app = _FormApp(tmp_path / "test.journal", rule=sample_rule)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.screen.is_edit is True
+
+    async def test_edit_form_prefills_description(self, tmp_path: Path, sample_rule):
+        """Edit form pre-fills the description field."""
+        app = _FormApp(tmp_path / "test.journal", rule=sample_rule)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            assert form.query_one("#recurring-input-description", Input).value == "Rent payment"
+
+    async def test_edit_form_preserves_rule_id(self, tmp_path: Path, sample_rule):
+        """Edit form preserves the original rule_id."""
+        app = _FormApp(tmp_path / "test.journal", rule=sample_rule)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            form._save()
+            await pilot.pause()
+            assert len(app.results) == 1
+            saved = app.results[0]
+            assert saved.rule_id == "rent-001"
+
+    async def test_edit_form_preserves_last_generated(self, tmp_path: Path, sample_rule):
+        """Edit form preserves the last_generated date."""
+        app = _FormApp(tmp_path / "test.journal", rule=sample_rule)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            form._save()
+            await pilot.pause()
+            assert len(app.results) == 1
+            saved = app.results[0]
+            assert saved.last_generated == "2026-02-01"
+
+    async def test_new_form_generates_new_rule_id(self, tmp_path: Path):
+        """New form generates a fresh rule_id."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            form.query_one("#recurring-input-description", Input).value = "Test"
+            from hledger_textual.widgets.posting_row import PostingRow
+            rows = list(form.query_one("#recurring-postings-container").query(PostingRow))
+            rows[0].query_one(f"#account-0", Input).value = "Expenses:Test"
+            rows[0].query_one(f"#amount-0", Input).value = "100.00"
+            rows[1].query_one(f"#account-1", Input).value = "Assets:Bank"
+            form._save()
+            await pilot.pause()
+            assert len(app.results) == 1
+            saved = app.results[0]
+            assert saved.rule_id.startswith("test-")
+            assert saved.last_generated is None
+
+
+@pytest.mark.skipif(not has_hledger(), reason="hledger not installed")
+class TestRecurringFormValidationHint:
+    """Tests for real-time validation hint in the custom period field."""
+
+    async def test_custom_period_shows_valid_hint(self, tmp_path: Path):
+        """Typing a valid custom period shows a green validation hint."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            # Select "Custom..."
+            form.query_one("#recurring-select-period", Select).value = "__custom__"
+            await pilot.pause()
+            # Type a valid expression
+            form.query_one("#recurring-input-custom-period", Input).value = "every friday"
+            await pilot.pause(delay=0.5)  # Wait for debounce + validation
+            hint = form.query_one("#custom-period-hint", Static)
+            assert hint.has_class("valid")
+
+    async def test_custom_period_shows_invalid_hint(self, tmp_path: Path):
+        """Typing an invalid custom period shows a red validation hint."""
+        app = _FormApp(tmp_path / "test.journal")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            form = app.screen
+            # Select "Custom..."
+            form.query_one("#recurring-select-period", Select).value = "__custom__"
+            await pilot.pause()
+            # Type an invalid expression
+            form.query_one("#recurring-input-custom-period", Input).value = "nonsense"
+            await pilot.pause(delay=0.5)  # Wait for debounce + validation
+            hint = form.query_one("#custom-period-hint", Static)
+            assert hint.has_class("invalid")

--- a/tests/test_recurring_pane.py
+++ b/tests/test_recurring_pane.py
@@ -1,0 +1,358 @@
+"""Integration tests for the Recurring pane."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from hledger_textual.app import HledgerTuiApp
+from hledger_textual.recurring import parse_recurring_rules
+from tests.conftest import has_hledger
+
+pytestmark = pytest.mark.skipif(not has_hledger(), reason="hledger not installed")
+
+
+@pytest.fixture
+def recurring_app_journal(tmp_path: Path) -> Path:
+    """A temporary journal with recurring rules for pane testing."""
+    today = date.today()
+    d1 = today.replace(day=1)
+
+    content = (
+        "include recurring.journal\n"
+        "\n"
+        f"{d1.isoformat()} * Opening balance\n"
+        "    Assets:Bank:Checking                 €10000.00\n"
+        "    Equity:Opening\n"
+    )
+    journal = tmp_path / "test.journal"
+    journal.write_text(content)
+
+    recurring_content = (
+        "~ monthly  Rent payment  ; recurring-id:rent-001, last-generated:2025-01-01\n"
+        "    Expenses:Rent                                   €800.00\n"
+        "    Assets:Bank:Checking\n"
+        "\n"
+        "~ weekly  Grocery run  ; recurring-id:grocery-001, last-generated:2025-01-01\n"
+        "    Expenses:Groceries                              €100.00\n"
+        "    Assets:Bank:Checking\n"
+    )
+    recurring = tmp_path / "recurring.journal"
+    recurring.write_text(recurring_content)
+
+    return journal
+
+
+@pytest.fixture
+def recurring_app(recurring_app_journal: Path) -> HledgerTuiApp:
+    """Create an app instance for recurring testing."""
+    return HledgerTuiApp(journal_file=recurring_app_journal)
+
+
+@pytest.fixture
+def empty_recurring_app(tmp_path: Path) -> HledgerTuiApp:
+    """Create an app with no recurring rules."""
+    today = date.today()
+    d1 = today.replace(day=1)
+
+    content = (
+        f"{d1.isoformat()} Test\n"
+        "    Expenses:Groceries                   €10.00\n"
+        "    assets:bank:checking\n"
+    )
+    journal = tmp_path / "test.journal"
+    journal.write_text(content)
+    return HledgerTuiApp(journal_file=journal)
+
+
+class TestRecurringTabSwitch:
+    """Tests for switching to the recurring tab."""
+
+    async def test_switch_to_recurring_via_key(self, recurring_app: HledgerTuiApp):
+        """Pressing 3 switches to the recurring pane."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause()
+            from textual.widgets import ContentSwitcher
+            switcher = recurring_app.screen.query_one("#content-switcher", ContentSwitcher)
+            assert switcher.current == "recurring"
+
+    async def test_recurring_table_has_rows(self, recurring_app: HledgerTuiApp):
+        """Recurring table shows rules when data exists."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            table = recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 2
+
+
+class TestRecurringEmptyState:
+    """Tests for the empty recurring state."""
+
+    async def test_empty_state_message(self, empty_recurring_app: HledgerTuiApp):
+        """Shows empty state message when no recurring rules exist."""
+        async with empty_recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            table = empty_recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 1
+
+
+class TestRecurringAdd:
+    """Tests for adding a recurring rule."""
+
+    async def test_add_shows_form(self, recurring_app: HledgerTuiApp):
+        """Pressing 'a' on recurring pane opens the form."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("a")
+            await pilot.pause()
+            from hledger_textual.screens.recurring_form import RecurringFormScreen
+            assert isinstance(recurring_app.screen, RecurringFormScreen)
+
+    async def test_add_cancel(self, recurring_app: HledgerTuiApp):
+        """Cancelling the add form does not add a rule."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("a")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            table = recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 2
+
+
+class TestRecurringDelete:
+    """Tests for deleting a recurring rule."""
+
+    async def test_delete_shows_confirm(self, recurring_app: HledgerTuiApp):
+        """Pressing 'd' shows delete confirmation."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("d")
+            await pilot.pause()
+            from hledger_textual.screens.recurring_delete_confirm import RecurringDeleteConfirmModal
+            assert isinstance(recurring_app.screen, RecurringDeleteConfirmModal)
+
+    async def test_delete_cancel(self, recurring_app: HledgerTuiApp):
+        """Cancelling delete does not remove the rule."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            table = recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 2
+
+    async def test_delete_confirm(
+        self, recurring_app: HledgerTuiApp, recurring_app_journal: Path
+    ):
+        """Confirming delete removes the rule."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("d")
+            await pilot.pause()
+            delete_btn = recurring_app.screen.query_one("#btn-recurring-delete")
+            await pilot.click(delete_btn)
+            await pilot.pause(delay=1.0)
+            recurring_path = recurring_app_journal.parent / "recurring.journal"
+            rules = parse_recurring_rules(recurring_path)
+            assert len(rules) == 1
+
+
+class TestRecurringFilter:
+    """Tests for recurring filter functionality."""
+
+    async def test_filter_shows_input(self, recurring_app: HledgerTuiApp):
+        """Pressing '/' shows the filter input."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("slash")
+            await pilot.pause()
+            from hledger_textual.widgets.recurring_pane import RecurringPane
+            pane = recurring_app.screen.query_one(RecurringPane)
+            filter_bar = pane.query_one(".filter-bar")
+            assert filter_bar.has_class("visible")
+
+    async def test_escape_dismisses_filter(self, recurring_app: HledgerTuiApp):
+        """Pressing Escape hides the filter."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("slash")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            from hledger_textual.widgets.recurring_pane import RecurringPane
+            pane = recurring_app.screen.query_one(RecurringPane)
+            filter_bar = pane.query_one(".filter-bar")
+            assert not filter_bar.has_class("visible")
+
+    async def test_filter_narrows_results(self, recurring_app: HledgerTuiApp):
+        """Typing in the filter shows only matching rules."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("slash")
+            await pilot.pause()
+            filter_input = recurring_app.screen.query_one("#recurring-filter-input")
+            filter_input.value = "Rent"
+            await pilot.pause()
+            table = recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 1
+
+
+class TestRecurringEdit:
+    """Tests for the edit action in RecurringPane."""
+
+    async def test_edit_opens_form_in_edit_mode(self, recurring_app: HledgerTuiApp):
+        """Pressing 'e' with a rule selected opens RecurringFormScreen in edit mode."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("e")
+            await pilot.pause()
+            from hledger_textual.screens.recurring_form import RecurringFormScreen
+            assert isinstance(recurring_app.screen, RecurringFormScreen)
+            assert recurring_app.screen.is_edit is True
+
+    async def test_edit_cancel_leaves_rules_unchanged(
+        self, recurring_app: HledgerTuiApp, recurring_app_journal: Path
+    ):
+        """Cancelling the edit form does not modify any rule."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("e")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            recurring_path = recurring_app_journal.parent / "recurring.journal"
+            rules = parse_recurring_rules(recurring_path)
+            assert len(rules) == 2
+
+
+class TestRecurringGenerate:
+    """Tests for the generate action."""
+
+    async def test_generate_shows_dialog(self, recurring_app: HledgerTuiApp):
+        """Pressing 'g' with pending rules shows the generate dialog."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("g")
+            await pilot.pause(delay=1.0)
+            from hledger_textual.screens.recurring_generate import RecurringGenerateScreen
+            assert isinstance(recurring_app.screen, RecurringGenerateScreen)
+
+
+class TestRecurringFooter:
+    """Tests for the recurring footer text."""
+
+    async def test_footer_updates_on_switch(self, recurring_app: HledgerTuiApp):
+        """Footer shows recurring-specific text when switching to recurring tab."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause()
+            from textual.widgets import Static
+            footer = recurring_app.screen.query_one("#footer-bar", Static)
+            rendered = str(footer.renderable)
+            assert "Generate" in rendered
+            assert "Add" in rendered
+
+
+class TestRecurringCursor:
+    """Tests for cursor movement bindings in RecurringPane."""
+
+    async def test_cursor_down(self, recurring_app: HledgerTuiApp):
+        """Pressing 'j' moves the cursor down without crashing."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("j")
+            await pilot.pause()
+            table = recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 2
+
+    async def test_cursor_up(self, recurring_app: HledgerTuiApp):
+        """Pressing 'k' moves the cursor up without crashing."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("j")
+            await pilot.pause()
+            await pilot.press("k")
+            await pilot.pause()
+            table = recurring_app.screen.query_one("#recurring-table")
+            assert table.row_count == 2
+
+
+class TestRecurringNoSelection:
+    """Tests for edit/delete actions when no valid rule is selected."""
+
+    async def test_edit_no_rule_stays_on_main_screen(
+        self, empty_recurring_app: HledgerTuiApp
+    ):
+        """Pressing 'e' with no rule selected does not push a form screen."""
+        async with empty_recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("e")
+            await pilot.pause()
+            from hledger_textual.screens.recurring_form import RecurringFormScreen
+            assert not isinstance(empty_recurring_app.screen, RecurringFormScreen)
+
+    async def test_delete_no_rule_stays_on_main_screen(
+        self, empty_recurring_app: HledgerTuiApp
+    ):
+        """Pressing 'd' with no rule selected does not push a confirm screen."""
+        async with empty_recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            await pilot.press("d")
+            await pilot.pause()
+            from hledger_textual.screens.recurring_delete_confirm import RecurringDeleteConfirmModal
+            assert not isinstance(empty_recurring_app.screen, RecurringDeleteConfirmModal)
+
+
+class TestRecurringRefresh:
+    """Tests for the refresh action in RecurringPane."""
+
+    async def test_refresh_keeps_row_count(self, recurring_app: HledgerTuiApp):
+        """Pressing 'r' reloads the data without changing the row count."""
+        async with recurring_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("3")
+            await pilot.pause(delay=1.0)
+            count_before = recurring_app.screen.query_one("#recurring-table").row_count
+            await pilot.press("r")
+            await pilot.pause(delay=1.0)
+            assert recurring_app.screen.query_one("#recurring-table").row_count == count_before

--- a/uv.lock
+++ b/uv.lock
@@ -411,7 +411,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "pricehist" },


### PR DESCRIPTION
Implement recurring transaction rules (CRUD, generation, pane/form UI). Delegate period expression validation and date computation to hledger, enabling full support for any hledger period expression (e.g. every 3rd thursday, every friday). Add debounced real-time validation hint in the custom period field.

Update reports.