### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.1.4"
+version = "0.1.5"
 description = "A terminal user interface for managing hledger journal transactions"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- Bump version from `0.1.4` to `0.1.5`
- Follows the merge of feat/recurring-transactions (#19)

## Test plan

- [ ] Verify `uv run hledger-textual --version` reports `0.1.5`