### PR TITLE
fix: use hledger account type queries instead of hardcoded account names

### DIFF
--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -482,30 +482,41 @@ def load_period_summary(file: str | Path, period: str | None = None) -> PeriodSu
     """
     period_args = ("-p", period) if period else ()
 
-    # Query 1: income and expenses (no -B, keeps original amounts)
-    output = run_hledger(
-        "balance", "income", "expenses",
-        *period_args, "--flat", "--no-total", "-O", "csv",
-        file=file,
-    )
-
+    # Query 1a: income/revenue accounts (type:R — respects account type metadata)
     income = Decimal("0")
     expenses = Decimal("0")
     commodity = ""
 
-    reader = csv.reader(io.StringIO(output))
-    next(reader, None)  # skip header
-    for row in reader:
+    output_r = run_hledger(
+        "balance", "type:R",
+        *period_args, "--flat", "--no-total", "-O", "csv",
+        file=file,
+    )
+    reader_r = csv.reader(io.StringIO(output_r))
+    next(reader_r, None)  # skip header
+    for row in reader_r:
         if len(row) < 2 or not row[0]:
             continue
-        account = row[0].strip().lower()
         qty, com = _parse_budget_amount(row[1].strip())
         if not commodity and com:
             commodity = com
-        if account.startswith("income"):
-            income += abs(qty)
-        elif account.startswith("expenses"):
-            expenses += abs(qty)
+        income += abs(qty)
+
+    # Query 1b: expense accounts (type:X — respects account type metadata)
+    output_x = run_hledger(
+        "balance", "type:X",
+        *period_args, "--flat", "--no-total", "-O", "csv",
+        file=file,
+    )
+    reader_x = csv.reader(io.StringIO(output_x))
+    next(reader_x, None)  # skip header
+    for row in reader_x:
+        if len(row) < 2 or not row[0]:
+            continue
+        qty, com = _parse_budget_amount(row[1].strip())
+        if not commodity and com:
+            commodity = com
+        expenses += abs(qty)
 
     # Query 2: investments at cost (-B converts units to purchase price)
     investments = Decimal("0")
@@ -541,8 +552,8 @@ def _load_account_breakdown(
 
     Args:
         file: Path to the journal file.
-        account_type: The top-level account to query (e.g. ``"expenses"``
-            or ``"income"``).
+        account_type: The account type query (e.g. ``"type:X"`` for expenses
+            or ``"type:R"`` for revenue/income).
         period: A period string like ``'2026-02'``.
 
     Returns:
@@ -589,7 +600,7 @@ def load_expense_breakdown(
     Raises:
         HledgerError: If hledger fails or is not found.
     """
-    return _load_account_breakdown(file, "expenses", period)
+    return _load_account_breakdown(file, "type:X", period)
 
 
 def load_income_breakdown(
@@ -608,7 +619,7 @@ def load_income_breakdown(
     Raises:
         HledgerError: If hledger fails or is not found.
     """
-    return _load_account_breakdown(file, "income", period)
+    return _load_account_breakdown(file, "type:R", period)
 
 
 def load_investment_positions(

--- a/tests/fixtures/account_types/custom_italian.journal
+++ b/tests/fixtures/account_types/custom_italian.journal
@@ -1,0 +1,24 @@
+; Scenario: Fully custom Italian names with type tags
+; No standard hledger name prefixes at all
+
+account attività           ; type: A
+account passività          ; type: L
+account entrate            ; type: R
+account uscite             ; type: X
+account patrimonio         ; type: E
+
+2026-03-01 Stipendio
+    attività:banca:conto       €3000.00
+    entrate:stipendio
+
+2026-03-02 Lavoro freelance
+    attività:banca:conto       €500.00
+    entrate:freelance
+
+2026-03-05 Spesa alimentare
+    uscite:cibo:supermercato   €120.00
+    attività:banca:conto
+
+2026-03-10 Bolletta elettricità
+    uscite:utenze              €80.00
+    attività:banca:conto

--- a/tests/fixtures/account_types/mixed.journal
+++ b/tests/fixtures/account_types/mixed.journal
@@ -1,0 +1,21 @@
+; Scenario: Mixed — some standard names, some type-tagged
+; income:* auto-detected + revenues:* with type tag
+
+account revenues       ; type: R
+account spese          ; type: X
+
+2026-03-01 Salary (standard)
+    assets:bank:checking       €3000.00
+    income:salary
+
+2026-03-02 Consulting (type-tagged)
+    assets:bank:checking       €500.00
+    revenues:consulting
+
+2026-03-05 Groceries (standard)
+    expenses:food              €120.00
+    assets:bank:checking
+
+2026-03-10 Office supplies (type-tagged)
+    spese:ufficio              €80.00
+    assets:bank:checking

--- a/tests/fixtures/account_types/standard.journal
+++ b/tests/fixtures/account_types/standard.journal
@@ -1,0 +1,18 @@
+; Scenario: Standard account names (income:* / expenses:*)
+; hledger auto-detects types from the name prefix
+
+2026-03-01 Salary
+    assets:bank:checking       €3000.00
+    income:salary
+
+2026-03-02 Freelance work
+    assets:bank:checking       €500.00
+    income:freelance
+
+2026-03-05 Groceries
+    expenses:food:groceries    €120.00
+    assets:bank:checking
+
+2026-03-10 Electricity bill
+    expenses:utilities         €80.00
+    assets:bank:checking

--- a/tests/fixtures/account_types/type_tagged_revenues.journal
+++ b/tests/fixtures/account_types/type_tagged_revenues.journal
@@ -1,0 +1,22 @@
+; Scenario: Non-standard "revenues:*" accounts with type: R tags
+; This is the bug scenario from issue #18
+
+account revenues           ; type: R
+account spese              ; type: X
+account attività:banca     ; type: A
+
+2026-03-01 Stipendio
+    attività:banca             €3000.00
+    revenues:salary
+
+2026-03-02 Consulenza
+    attività:banca             €500.00
+    revenues:freelance
+
+2026-03-05 Spesa alimentare
+    spese:cibo                 €120.00
+    attività:banca
+
+2026-03-10 Bolletta luce
+    spese:utenze               €80.00
+    attività:banca

--- a/tests/test_hledger.py
+++ b/tests/test_hledger.py
@@ -781,3 +781,95 @@ class TestLoadIncomeBreakdown:
         """A period with no transactions should return an empty list."""
         breakdown = load_income_breakdown(income_journal, "1999-01")
         assert breakdown == []
+
+
+# ---------------------------------------------------------------------------
+#  Account type query tests (issue #18)
+#  Verify that type:R / type:X queries work with all naming conventions.
+# ---------------------------------------------------------------------------
+
+ACCOUNT_TYPE_FIXTURES = Path(__file__).parent / "fixtures" / "account_types"
+
+_ACCOUNT_TYPE_JOURNALS = [
+    pytest.param("standard.journal", id="standard"),
+    pytest.param("type_tagged_revenues.journal", id="type-tagged-revenues"),
+    pytest.param("mixed.journal", id="mixed"),
+    pytest.param("custom_italian.journal", id="custom-italian"),
+]
+
+
+class TestAccountTypeQueries:
+    """Ensure income/expense queries work regardless of account naming.
+
+    All four fixture journals contain the same monetary totals
+    (income €3500, expenses €200) but use different account names
+    and type tag configurations.
+    """
+
+    PERIOD = "2026-03"
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_period_summary_income(self, journal_name: str):
+        """load_period_summary returns correct income for all naming styles."""
+        summary = load_period_summary(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        assert summary.income == Decimal("3500.00")
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_period_summary_expenses(self, journal_name: str):
+        """load_period_summary returns correct expenses for all naming styles."""
+        summary = load_period_summary(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        assert summary.expenses == Decimal("200.00")
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_period_summary_net(self, journal_name: str):
+        """load_period_summary returns correct net for all naming styles."""
+        summary = load_period_summary(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        assert summary.net == Decimal("3300.00")
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_period_summary_commodity(self, journal_name: str):
+        """load_period_summary detects commodity for all naming styles."""
+        summary = load_period_summary(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        assert summary.commodity == "€"
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_income_breakdown_count(self, journal_name: str):
+        """load_income_breakdown returns two accounts for all naming styles."""
+        breakdown = load_income_breakdown(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        assert len(breakdown) == 2
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_income_breakdown_amounts(self, journal_name: str):
+        """load_income_breakdown returns correct amounts for all naming styles."""
+        breakdown = load_income_breakdown(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        amounts = sorted([row[1] for row in breakdown], reverse=True)
+        assert amounts == [Decimal("3000.00"), Decimal("500.00")]
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_expense_breakdown_count(self, journal_name: str):
+        """load_expense_breakdown returns two accounts for all naming styles."""
+        breakdown = load_expense_breakdown(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        assert len(breakdown) == 2
+
+    @pytest.mark.parametrize("journal_name", _ACCOUNT_TYPE_JOURNALS)
+    def test_expense_breakdown_amounts(self, journal_name: str):
+        """load_expense_breakdown returns correct amounts for all naming styles."""
+        breakdown = load_expense_breakdown(
+            ACCOUNT_TYPE_FIXTURES / journal_name, self.PERIOD,
+        )
+        amounts = sorted([row[1] for row in breakdown], reverse=True)
+        assert amounts == [Decimal("120.00"), Decimal("80.00")]


### PR DESCRIPTION
## Summary
- Replace hardcoded `"income"`/`"expenses"` account name queries with `type:R`/`type:X` queries that respect hledger's account type metadata
- Fixes summary/breakdown for journals using non-English account names or custom type declarations
- Adds 32 parametrized tests across 4 fixture journals (standard, type-tagged, mixed, custom Italian)

## Test plan
- [x] `uv run pytest tests/test_hledger.py::TestAccountTypeQueries -v` — 32/32 pass