### PR TITLE
feat: add check for updates via PyPI with 24-hour cache

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -106,6 +106,29 @@ class HledgerTuiApp(App):
     def on_mount(self) -> None:
         """Focus the default section after mount."""
         self._focus_section("summary")
+        self._check_for_updates()
+
+    @work(thread=True, exclusive=True, group="startup-update-check")
+    def _check_for_updates(self) -> None:
+        """Check PyPI for a newer version and notify once if found."""
+        import importlib.metadata
+
+        from hledger_textual.updates import get_latest_version, is_newer
+
+        try:
+            meta = importlib.metadata.metadata("hledger-textual")
+            current = meta.get("Version", "0")
+        except importlib.metadata.PackageNotFoundError:
+            return
+
+        latest = get_latest_version()
+        if latest and is_newer(latest, current):
+            self.app.call_from_thread(
+                self.notify,
+                f"hledger-textual v{latest} is available (current: v{current})",
+                severity="information",
+                timeout=8,
+            )
 
     def on_tabs_tab_activated(self, event: Tabs.TabActivated) -> None:
         """Handle tab activation (click) — switch content and focus."""

--- a/src/hledger_textual/updates.py
+++ b/src/hledger_textual/updates.py
@@ -1,0 +1,104 @@
+"""Update check module: queries PyPI for the latest version with a 24-hour cache."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_CACHE_PATH = Path.home() / ".cache" / "hledger-textual" / "update_check.json"
+_PYPI_URL = "https://pypi.org/pypi/hledger-textual/json"
+_CACHE_TTL = timedelta(hours=24)
+
+
+def _fetch_latest_version() -> str | None:
+    """Fetch the latest published version from PyPI.
+
+    Returns:
+        Version string (e.g. ``"0.1.8"``), or ``None`` on any error.
+    """
+    try:
+        with urllib.request.urlopen(_PYPI_URL, timeout=5) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+            return data["info"]["version"]
+    except Exception:
+        return None
+
+
+def _read_cache() -> tuple[str | None, datetime | None]:
+    """Read the cached latest version and its timestamp.
+
+    Returns:
+        ``(version, checked_at)`` tuple; both ``None`` if the cache is absent
+        or unreadable.
+    """
+    try:
+        with open(_CACHE_PATH) as f:
+            data = json.load(f)
+        return data["latest_version"], datetime.fromisoformat(data["checked_at"])
+    except Exception:
+        return None, None
+
+
+def _write_cache(version: str) -> None:
+    """Persist the latest version and current timestamp to the cache file."""
+    try:
+        _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(_CACHE_PATH, "w") as f:
+            json.dump(
+                {"latest_version": version, "checked_at": datetime.now().isoformat()},
+                f,
+            )
+    except Exception:
+        pass
+
+
+def get_latest_version() -> str | None:
+    """Return the latest hledger-textual version from PyPI, with a 24-hour cache.
+
+    Reads the local cache first. Fetches from PyPI only when the cache is
+    absent or older than 24 hours. Falls back to the stale cached value if
+    the network request fails.
+
+    Returns:
+        Version string (e.g. ``"0.1.8"``), or ``None`` if unavailable.
+    """
+    cached_version, checked_at = _read_cache()
+    cache_fresh = (
+        cached_version is not None
+        and checked_at is not None
+        and datetime.now() - checked_at < _CACHE_TTL
+    )
+    if cache_fresh:
+        return cached_version
+
+    fetched = _fetch_latest_version()
+    if fetched:
+        _write_cache(fetched)
+        return fetched
+
+    # Network failed — return stale cache rather than nothing
+    return cached_version
+
+
+def is_newer(latest: str, current: str) -> bool:
+    """Return True if *latest* is strictly newer than *current*.
+
+    Compares using tuple comparison of integer version components so that
+    ``"0.1.10"`` is correctly treated as newer than ``"0.1.9"``.
+
+    Args:
+        latest: The version string fetched from PyPI.
+        current: The installed version string.
+
+    Returns:
+        ``True`` if an upgrade is available.
+    """
+    def _parse(v: str) -> tuple[int, ...]:
+        try:
+            return tuple(int(x) for x in v.split("."))
+        except ValueError:
+            return (0,)
+
+    return _parse(latest) > _parse(current)

--- a/src/hledger_textual/widgets/info_pane.py
+++ b/src/hledger_textual/widgets/info_pane.py
@@ -15,6 +15,7 @@ from hledger_textual.config import _CONFIG_PATH
 from hledger_textual.git import git_branch, git_status_summary, is_git_repo
 from hledger_textual.hledger import HledgerError, get_hledger_version, load_journal_stats
 from hledger_textual.prices import get_pricehist_version, has_pricehist
+from hledger_textual.updates import get_latest_version, is_newer
 
 
 def _fmt_size(n: int) -> str:
@@ -100,6 +101,9 @@ class InfoPane(Widget):
                     with Horizontal(classes="info-row"):
                         yield Static("Repository", classes="info-label")
                         yield Static("", id="info-repo")
+                    with Horizontal(classes="info-row"):
+                        yield Static("Latest", classes="info-label")
+                        yield Static("Checking…", id="info-latest-version")
 
                 with Vertical(classes="info-section"):
                     yield Static("hledger", classes="info-section-title")
@@ -130,6 +134,7 @@ class InfoPane(Widget):
         self._load_journal_data()
         self._load_hledger_info()
         self._load_git_info()
+        self._load_update_check()
 
     def _apply_project_metadata(self) -> None:
         """Read project metadata from package info and display it."""
@@ -244,6 +249,28 @@ class InfoPane(Widget):
         self.query_one("#info-git-section").styles.display = "block"
         self.query_one("#info-git-branch", Static).update(branch)
         self.query_one("#info-git-status", Static).update(status)
+
+    @work(thread=True, exclusive=True, group="info-update-check")
+    def _load_update_check(self) -> None:
+        """Check PyPI for the latest version in a background thread."""
+        try:
+            meta = importlib.metadata.metadata("hledger-textual")
+            current = meta.get("Version", "0")
+        except importlib.metadata.PackageNotFoundError:
+            current = "0"
+
+        latest = get_latest_version()
+        self.app.call_from_thread(self._apply_update_check, current, latest)
+
+    def _apply_update_check(self, current: str, latest: str | None) -> None:
+        """Update the Latest version field in the About section."""
+        widget = self.query_one("#info-latest-version", Static)
+        if latest is None:
+            widget.update("Unavailable")
+        elif is_newer(latest, current):
+            widget.update(f"[bold yellow]v{latest} available[/bold yellow]")
+        else:
+            widget.update(f"v{latest} (up to date)")
 
     def refresh_git_status(self) -> None:
         """Reload git info (called after a sync operation)."""

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,0 +1,106 @@
+"""Tests for the update check module."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from hledger_textual.updates import _CACHE_TTL, get_latest_version, is_newer
+
+
+class TestIsNewer:
+    """Tests for the is_newer version comparison helper."""
+
+    def test_newer_patch(self):
+        assert is_newer("0.1.8", "0.1.7") is True
+
+    def test_newer_minor(self):
+        assert is_newer("0.2.0", "0.1.9") is True
+
+    def test_newer_major(self):
+        assert is_newer("1.0.0", "0.9.9") is True
+
+    def test_same_version(self):
+        assert is_newer("0.1.7", "0.1.7") is False
+
+    def test_older_version(self):
+        assert is_newer("0.1.6", "0.1.7") is False
+
+    def test_double_digit_patch(self):
+        assert is_newer("0.1.10", "0.1.9") is True
+
+
+class TestGetLatestVersion:
+    """Tests for get_latest_version with mocked cache and network."""
+
+    def test_returns_cached_version_when_fresh(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "update_check.json"
+        cache_file.write_text(json.dumps({
+            "latest_version": "0.1.8",
+            "checked_at": datetime.now().isoformat(),
+        }))
+        monkeypatch.setattr("hledger_textual.updates._CACHE_PATH", cache_file)
+
+        with patch("hledger_textual.updates._fetch_latest_version") as mock_fetch:
+            result = get_latest_version()
+
+        assert result == "0.1.8"
+        mock_fetch.assert_not_called()
+
+    def test_fetches_when_cache_stale(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "update_check.json"
+        stale_time = datetime.now() - _CACHE_TTL - timedelta(minutes=1)
+        cache_file.write_text(json.dumps({
+            "latest_version": "0.1.7",
+            "checked_at": stale_time.isoformat(),
+        }))
+        monkeypatch.setattr("hledger_textual.updates._CACHE_PATH", cache_file)
+
+        with patch("hledger_textual.updates._fetch_latest_version", return_value="0.1.8"):
+            result = get_latest_version()
+
+        assert result == "0.1.8"
+
+    def test_fetches_when_no_cache(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "update_check.json"
+        monkeypatch.setattr("hledger_textual.updates._CACHE_PATH", cache_file)
+
+        with patch("hledger_textual.updates._fetch_latest_version", return_value="0.1.8"):
+            result = get_latest_version()
+
+        assert result == "0.1.8"
+
+    def test_falls_back_to_stale_cache_on_network_error(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "update_check.json"
+        stale_time = datetime.now() - _CACHE_TTL - timedelta(minutes=1)
+        cache_file.write_text(json.dumps({
+            "latest_version": "0.1.7",
+            "checked_at": stale_time.isoformat(),
+        }))
+        monkeypatch.setattr("hledger_textual.updates._CACHE_PATH", cache_file)
+
+        with patch("hledger_textual.updates._fetch_latest_version", return_value=None):
+            result = get_latest_version()
+
+        assert result == "0.1.7"
+
+    def test_returns_none_when_no_cache_and_network_fails(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "update_check.json"
+        monkeypatch.setattr("hledger_textual.updates._CACHE_PATH", cache_file)
+
+        with patch("hledger_textual.updates._fetch_latest_version", return_value=None):
+            result = get_latest_version()
+
+        assert result is None
+
+    def test_writes_cache_after_fetch(self, tmp_path, monkeypatch):
+        cache_file = tmp_path / "update_check.json"
+        monkeypatch.setattr("hledger_textual.updates._CACHE_PATH", cache_file)
+
+        with patch("hledger_textual.updates._fetch_latest_version", return_value="0.1.8"):
+            get_latest_version()
+
+        data = json.loads(cache_file.read_text())
+        assert data["latest_version"] == "0.1.8"
+        assert "checked_at" in data


### PR DESCRIPTION
- Query PyPI on startup to check for a newer version of hledger-textual
- Cache the result for 24 hours in ~/.cache/hledger-textual/update_check.json to avoid a network request on every launch; falls back to stale cache if the network is unavailable
- Show a non-intrusive notification at startup if a newer version is found
- Display the latest version in the Info tab (About section), highlighted in yellow when an update is available