### PR TITLE
fix: restrict theme picker [t] binding to Info tab only

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -9,7 +9,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import ContentSwitcher, DataTable, Static, Tab, Tabs
 
-from hledger_textual.config import load_theme, save_theme
+from hledger_textual.config import load_theme
 from hledger_textual.widgets.accounts_pane import AccountsPane
 from hledger_textual.widgets.budget_pane import BudgetPane
 from hledger_textual.widgets.info_pane import InfoPane
@@ -64,7 +64,6 @@ class HledgerTuiApp(App):
         Binding("7", "switch_section('info')", "Info", show=False),
         Binding("s", "git_sync", "Sync", show=False),
         Binding("q", "quit", "Quit"),
-        Binding("t", "pick_theme", "Theme", show=False),
     ]
 
     def __init__(self, journal_file: Path) -> None:
@@ -201,15 +200,3 @@ class HledgerTuiApp(App):
         self.app.call_from_thread(
             self.query_one(InfoPane).refresh_git_status
         )
-
-    def action_pick_theme(self) -> None:
-        """Open the theme picker dialog."""
-        from hledger_textual.screens.theme_picker import ThemePickerModal
-
-        def on_theme_selected(theme: str | None) -> None:
-            if theme is not None:
-                self.theme = theme
-                save_theme(theme)
-                self.query_one(InfoPane).apply_theme(theme)
-
-        self.push_screen(ThemePickerModal(), callback=on_theme_selected)

--- a/src/hledger_textual/widgets/info_pane.py
+++ b/src/hledger_textual/widgets/info_pane.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from textual import work
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widget import Widget
 from textual.widgets import Static
@@ -38,7 +39,9 @@ class InfoPane(Widget):
 
     CAN_FOCUS = True
 
-    BINDINGS: list[Binding] = []
+    BINDINGS = [
+        Binding("t", "pick_theme", "Theme", show=True, priority=True),
+    ]
 
     def __init__(self, journal_file: Path, **kwargs) -> None:
         """Initialize the info pane.
@@ -248,3 +251,16 @@ class InfoPane(Widget):
     def refresh_git_status(self) -> None:
         """Reload git info (called after a sync operation)."""
         self._load_git_info()
+
+    def action_pick_theme(self) -> None:
+        """Open the theme picker dialog."""
+        from hledger_textual.config import save_theme
+        from hledger_textual.screens.theme_picker import ThemePickerModal
+
+        def on_theme_selected(theme: str | None) -> None:
+            if theme is not None:
+                self.app.theme = theme
+                save_theme(theme)
+                self.apply_theme(theme)
+
+        self.app.push_screen(ThemePickerModal(), callback=on_theme_selected)


### PR DESCRIPTION
The [t] key was bound at the app level, triggering the theme picker from any tab. Moved the binding and action into InfoPane with priority=True so it only fires when the Info tab is focused.