### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.1.7"
+version = "0.1.8"
 description = "A terminal user interface for managing hledger journal transactions"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8

## Changelog
- feat: add check for updates via PyPI with 24-hour cache
- fix: restrict theme picker [t] binding to Info tab only