### PR TITLE
fix: restore theme picker [t] binding and remove version prefix

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -63,6 +63,7 @@ class HledgerTuiApp(App):
         Binding("6", "switch_section('accounts')", "Accounts", show=False),
         Binding("7", "switch_section('info')", "Info", show=False),
         Binding("s", "git_sync", "Sync", show=False),
+        Binding("t", "pick_theme", "Theme", show=False),
         Binding("q", "quit", "Quit"),
     ]
 
@@ -124,7 +125,7 @@ class HledgerTuiApp(App):
         if latest and is_newer(latest, current):
             self.app.call_from_thread(
                 self.notify,
-                f"hledger-textual v{latest} is available (current: v{current})",
+                f"hledger-textual {latest} is available (current: {current})",
                 severity="information",
                 timeout=8,
             )
@@ -186,6 +187,12 @@ class HledgerTuiApp(App):
     def action_switch_section(self, section: str) -> None:
         """Switch to the given section via keyboard shortcut (1-6)."""
         self._activate_section(section)
+
+    def action_pick_theme(self) -> None:
+        """Open the theme picker when on the Info tab."""
+        switcher = self.query_one("#content-switcher", ContentSwitcher)
+        if switcher.current == "info":
+            self.query_one(InfoPane).action_pick_theme()
 
     def action_git_sync(self) -> None:
         """Show confirmation dialog, then commit + pull + push via git."""

--- a/src/hledger_textual/widgets/info_pane.py
+++ b/src/hledger_textual/widgets/info_pane.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from textual import work
 from textual.app import ComposeResult
-from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widget import Widget
 from textual.widgets import Static
@@ -39,10 +38,6 @@ class InfoPane(Widget):
     """Widget showing journal metadata and project information."""
 
     CAN_FOCUS = True
-
-    BINDINGS = [
-        Binding("t", "pick_theme", "Theme", show=True, priority=True),
-    ]
 
     def __init__(self, journal_file: Path, **kwargs) -> None:
         """Initialize the info pane.
@@ -271,9 +266,9 @@ class InfoPane(Widget):
         if latest is None:
             widget.update("Unavailable")
         elif is_newer(latest, current):
-            widget.update(f"[bold yellow]v{latest} available[/bold yellow]")
+            widget.update(f"[bold yellow]{latest} available[/bold yellow]")
         else:
-            widget.update(f"v{latest} (up to date)")
+            widget.update(f"{latest} (up to date)")
 
     def refresh_git_status(self) -> None:
         """Reload git info (called after a sync operation)."""


### PR DESCRIPTION
## Summary
- Restore `[t]` theme picker binding at app level with Info tab check (was broken when moved to widget level)
- Remove `v` prefix from version display in Info tab and toast notification for consistency

## Test plan
- [ ] Press `[t]` on Info tab → theme picker opens
- [ ] Press `[t]` on Transactions/Budget tabs → navigates to current month (no theme picker)
- [ ] Press `[t]` on other tabs → no action
- [ ] Verify Latest version in Info tab shows without "v" prefix