### PR TITLE
feat: add transaction status toggle via * and ! keys

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -21,7 +21,7 @@ from hledger_textual.widgets.transactions_table import TransactionsTable
 
 _FOOTER_COMMANDS: dict[str, str] = {
     "summary": "\\[r] Reload  \\[s] Sync  \\[q] Quit",
-    "transactions": "\\[a] Add  \\[e] Edit  \\[d] Delete  \\[◄/►] Month  \\[t] Today  \\[/] Search  \\[r] Reload  \\[s] Sync  \\[q] Quit",
+    "transactions": "\\[a] Add  \\[e] Edit  \\[d] Delete  \\[*] Cleared  \\[!] Pending  \\[◄/►] Month  \\[t] Today  \\[/] Search  \\[r] Reload  \\[s] Sync  \\[q] Quit",
     "accounts": "\\[↵] Drill  \\[/] Search  \\[r] Reload  \\[s] Sync  \\[q] Quit",
     "budget": "\\[a] Add  \\[e] Edit  \\[d] Delete  \\[◄/►] Month  \\[t] Today  \\[/] Search  \\[s] Sync  \\[q] Quit",
     "reports": "\\[c] Chart  \\[i] Inv  \\[r] Reload  \\[s] Sync  \\[q] Quit",

--- a/src/hledger_textual/widgets/transactions_pane.py
+++ b/src/hledger_textual/widgets/transactions_pane.py
@@ -11,7 +11,7 @@ from textual.binding import Binding
 from textual.widget import Widget
 
 from hledger_textual.hledger import HledgerError, load_period_summary
-from hledger_textual.models import Transaction
+from hledger_textual.models import Transaction, TransactionStatus
 from hledger_textual.widgets.period_summary_cards import PeriodSummaryCards
 from hledger_textual.widgets.transactions_table import TransactionsTable
 
@@ -36,6 +36,14 @@ class TransactionsPane(Widget):
         Binding("left", "prev_month", "Previous month", show=False, priority=True),
         Binding("right", "next_month", "Next month", show=False, priority=True),
         Binding("t", "today_month", "Today", show=False, priority=True),
+        Binding("*", "toggle_cleared", "Toggle cleared", show=False, priority=True),
+        Binding(
+            "exclamation_mark",
+            "toggle_pending",
+            "Toggle pending",
+            show=False,
+            priority=True,
+        ),
     ]
 
     def __init__(self, journal_file: Path, **kwargs) -> None:
@@ -128,6 +136,14 @@ class TransactionsPane(Widget):
     def action_delete(self) -> None:
         """Delete the selected transaction (with confirmation)."""
         self._table.do_delete()
+
+    def action_toggle_cleared(self) -> None:
+        """Toggle the cleared status of the selected transaction."""
+        self._table.do_toggle_status(TransactionStatus.CLEARED)
+
+    def action_toggle_pending(self) -> None:
+        """Toggle the pending status of the selected transaction."""
+        self._table.do_toggle_status(TransactionStatus.PENDING)
 
     # ------------------------------------------------------------------
     # Summary loading

--- a/src/hledger_textual/widgets/transactions_table.py
+++ b/src/hledger_textual/widgets/transactions_table.py
@@ -16,7 +16,7 @@ from textual.widgets import DataTable, Input, Static
 from hledger_textual.dateutil import next_month as _next_month
 from hledger_textual.dateutil import prev_month as _prev_month
 from hledger_textual.hledger import HledgerError, expand_search_query, load_transactions
-from hledger_textual.models import Transaction
+from hledger_textual.models import Transaction, TransactionStatus
 from hledger_textual.widgets import distribute_column_widths
 from hledger_textual.widgets.pane_toolbar import PaneToolbar
 
@@ -278,6 +278,44 @@ class TransactionsTable(Widget):
         try:
             replace_transaction(self.journal_file, original, updated)
             self.app.call_from_thread(self.notify, "Transaction updated", timeout=3)
+            self.app.call_from_thread(self.post_message, self.JournalChanged())
+        except JournalError as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+
+    def do_toggle_status(self, target: TransactionStatus) -> None:
+        """Toggle the status of the selected transaction.
+
+        If the current status matches *target*, revert to UNMARKED;
+        otherwise set it to *target*.
+        """
+        import dataclasses
+
+        txn = self.get_selected_transaction()
+        if txn is None:
+            self.notify("No transaction selected", severity="warning", timeout=3)
+            return
+
+        new_status = (
+            TransactionStatus.UNMARKED if txn.status == target else target
+        )
+        updated = dataclasses.replace(txn, status=new_status)
+        self._do_toggle_status(txn, updated)
+
+    @work(thread=True)
+    def _do_toggle_status(
+        self, original: Transaction, updated: Transaction
+    ) -> None:
+        """Persist a status change and emit JournalChanged."""
+        from hledger_textual.journal import JournalError, replace_transaction
+
+        try:
+            replace_transaction(self.journal_file, original, updated)
+            label = updated.status.value.lower()
+            self.app.call_from_thread(
+                self.notify, f"Status set to {label}", timeout=3
+            )
             self.app.call_from_thread(self.post_message, self.JournalChanged())
         except JournalError as exc:
             self.app.call_from_thread(

--- a/tests/test_transactions_table.py
+++ b/tests/test_transactions_table.py
@@ -341,6 +341,98 @@ class TestTransactionsTableEditFlow:
             assert app.query_one("#transactions-table") is not None
 
 
+@pytest.mark.skipif(not has_hledger(), reason="hledger not installed")
+class TestTransactionsTableStatusToggle:
+    """Tests for do_toggle_status (status toggle via * and ! keys)."""
+
+    async def test_toggle_cleared_on_unmarked(self, table_journal: Path):
+        """Pressing * on an unmarked transaction sets it to cleared."""
+        from hledger_textual.hledger import load_transactions
+        from hledger_textual.models import TransactionStatus
+
+        app = HledgerTuiApp(journal_file=table_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=1.0)
+            await pilot.press("2")  # Switch to Transactions tab
+            await pilot.pause(delay=1.0)
+            # Row 0 is Salary (newest first, reverse order), which is unmarked
+            await pilot.press("*")
+            await pilot.pause(delay=1.5)
+            txns = load_transactions(table_journal)
+            salary = [t for t in txns if t.description == "Salary"][0]
+            assert salary.status == TransactionStatus.CLEARED
+
+    async def test_toggle_cleared_off(self, table_journal: Path):
+        """Pressing * on a cleared transaction reverts to unmarked."""
+        from hledger_textual.hledger import load_transactions
+        from hledger_textual.models import TransactionStatus
+
+        app = HledgerTuiApp(journal_file=table_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=1.0)
+            await pilot.press("2")
+            await pilot.pause(delay=1.0)
+            # Move to row 1: Grocery shopping (cleared)
+            await pilot.press("down")
+            await pilot.pause()
+            await pilot.press("*")
+            await pilot.pause(delay=1.5)
+            txns = load_transactions(table_journal)
+            grocery = [t for t in txns if "Grocery" in t.description][0]
+            assert grocery.status == TransactionStatus.UNMARKED
+
+    async def test_toggle_pending_on_unmarked(self, table_journal: Path):
+        """Pressing ! on an unmarked transaction sets it to pending."""
+        from hledger_textual.hledger import load_transactions
+        from hledger_textual.models import TransactionStatus
+
+        app = HledgerTuiApp(journal_file=table_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=1.0)
+            await pilot.press("2")
+            await pilot.pause(delay=1.0)
+            # Row 0 is Salary (unmarked)
+            await pilot.press("exclamation_mark")
+            await pilot.pause(delay=1.5)
+            txns = load_transactions(table_journal)
+            salary = [t for t in txns if t.description == "Salary"][0]
+            assert salary.status == TransactionStatus.PENDING
+
+    async def test_cross_toggle_pending_to_cleared(self, table_journal: Path):
+        """Pressing * on a pending transaction sets it to cleared."""
+        from hledger_textual.hledger import load_transactions
+        from hledger_textual.models import TransactionStatus
+
+        app = HledgerTuiApp(journal_file=table_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=1.0)
+            await pilot.press("2")
+            await pilot.pause(delay=1.0)
+            # Row 0 is Salary (unmarked) — set to pending first
+            await pilot.press("exclamation_mark")
+            await pilot.pause(delay=1.5)
+            # Then toggle to cleared
+            await pilot.press("*")
+            await pilot.pause(delay=1.5)
+            txns = load_transactions(table_journal)
+            salary = [t for t in txns if t.description == "Salary"][0]
+            assert salary.status == TransactionStatus.CLEARED
+
+    async def test_toggle_status_empty_table(self, empty_table_journal: Path):
+        """do_toggle_status is a no-op when no transaction is selected."""
+        from hledger_textual.models import TransactionStatus
+
+        app = _TableApp(empty_table_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=1.0)
+            txn_table = app.query_one(TransactionsTable)
+            txn_table.do_toggle_status(TransactionStatus.CLEARED)
+            await pilot.pause()
+            # Should not crash; table stays empty
+            table = app.query_one("#transactions-table")
+            assert table.row_count == 0
+
+
 class TestTransactionsTableLoadErrors:
     """Tests for HledgerError handling in background load workers."""
 


### PR DESCRIPTION
## Summary
- Add `*` and `!` keyboard shortcuts to toggle cleared/pending status directly from the transactions list
- Pressing the same key again reverts to unmarked (toggle behavior)
- Status changes are persisted to the journal file via `replace_transaction`

## Test plan
- [x] Unit tests for toggle cleared on/off, toggle pending, cross-toggle, and empty table
- [ ] Manual test: select a transaction, press `*` to set cleared, press `*` again to revert
- [ ] Manual test: press `!` to set pending, then `*` to switch to cleared