### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.1.9"
+version = "0.1.10"
 description = "A terminal user interface for managing hledger journal transactions"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version from 0.1.9 to 0.1.10

## Changes
- `pyproject.toml`: version 0.1.9 → 0.1.10