### PR TITLE
feat: add custom report builder (closes #44)

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -38,7 +38,8 @@ def _build_footer_commands(sync_enabled: bool) -> dict[str, str]:
         "transactions": f"\\[a] Add  \\[e] Edit  \\[d] Del  \\[c] Clone  \\[m] Move  \\[◄/►] Month  \\[/] Search  \\[f] Filters  \\[^s] Save filter  {global_part}",
         "accounts": f"\\[↵] Drill  \\[/] Search  \\[r] Reload  {global_part}",
         "budget": f"\\[a] Add  \\[e] Edit  \\[d] Del  \\[◄/►] Month  \\[/] Search  {global_part}",
-        "reports": f"\\[c] Chart  \\[i] Inv  \\[r] Reload  {global_part}",
+        "reports": f"\\[n] New  \\[c] Chart  \\[i] Inv  \\[r] Reload  {global_part}",
+        "reports-custom": f"\\[esc] Back  \\[n] New  \\[e] Edit  \\[d] Del  \\[r] Reload  {global_part}",
         "recurring": f"\\[a] Add  \\[e] Edit  \\[d] Del  \\[g] Generate  \\[r] Reload  {global_part}",
     }
 
@@ -272,6 +273,15 @@ class HledgerTuiApp(App):
     ) -> None:
         """Silently refresh all data panes after recurring transactions are generated."""
         self._refresh_all_panes()
+
+    def on_reports_pane_custom_report_state_changed(
+        self, event: ReportsPane.CustomReportStateChanged
+    ) -> None:
+        """Update the Reports footer when switching between built-in and custom modes."""
+        key = "reports-custom" if event.active else "reports"
+        self.query_one("#footer-bar", Static).update(
+            self._footer_commands.get(key, "")
+        )
 
     def action_switch_section(self, section: str) -> None:
         """Switch to the given section via keyboard shortcut (1-6)."""

--- a/src/hledger_textual/config.py
+++ b/src/hledger_textual/config.py
@@ -226,6 +226,48 @@ def load_rules_dir() -> Path | None:
     return None
 
 
+def load_custom_reports() -> dict[str, str]:
+    """Return saved custom reports from config.toml.
+
+    Reads the ``[custom_reports]`` section, where each key is a report name and
+    each value is an hledger command string (args without the ``-f`` flag).
+
+    Returns:
+        A dict mapping report name → hledger command string.
+        Returns an empty dict when no ``[custom_reports]`` section exists.
+    """
+    config = _load_config_dict()
+    reports = config.get("custom_reports", {})
+    return {str(k): str(v) for k, v in reports.items()}
+
+
+def save_custom_report(name: str, command: str) -> None:
+    """Save a named custom report to config.toml.
+
+    Args:
+        name: Display name for the report.
+        command: hledger command string (args without ``-f``).
+    """
+    data = _load_config_dict()
+    if "custom_reports" not in data:
+        data["custom_reports"] = {}
+    data["custom_reports"][name] = command
+    _save_config_dict(data)
+
+
+def delete_custom_report(name: str) -> None:
+    """Delete a named custom report from config.toml.
+
+    Args:
+        name: The report name to remove.  No-op if the name does not exist.
+    """
+    data = _load_config_dict()
+    reports = data.get("custom_reports", {})
+    reports.pop(name, None)
+    data["custom_reports"] = reports
+    _save_config_dict(data)
+
+
 def load_sync_config() -> dict | None:
     """Return sync configuration, or None if sync is disabled.
 

--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import shlex
 import subprocess
 from decimal import Decimal
 from pathlib import Path
@@ -1186,3 +1187,24 @@ def load_report(
         cache.put(cache_key, result, file=file)
 
     return result
+
+
+def run_custom_report(file: str | Path, command: str) -> str:
+    """Run a custom hledger command and return the raw text output.
+
+    The ``command`` string is split with :func:`shlex.split`, so quoting
+    rules follow standard shell conventions.
+
+    Args:
+        file: Path to the journal file.
+        command: hledger argument string without the ``-f`` flag
+            (e.g. ``"balance expenses --tree -M"``).
+
+    Returns:
+        The raw stdout output as a string.
+
+    Raises:
+        HledgerError: If hledger fails or is not found.
+    """
+    args = shlex.split(command)
+    return run_hledger(*args, file=file)

--- a/src/hledger_textual/models.py
+++ b/src/hledger_textual/models.py
@@ -318,6 +318,18 @@ class CsvRulesFile:
 
 
 @dataclass
+class CustomReport:
+    """A user-defined custom hledger report.
+
+    The ``command`` field holds the hledger argument string without the
+    ``-f`` journal flag (e.g. ``"balance expenses --tree -M"``).
+    """
+
+    name: str
+    command: str
+
+
+@dataclass
 class ReportData:
     """Parsed output of a multi-period hledger report (IS, BS, CF).
 

--- a/src/hledger_textual/screens/custom_report_delete_confirm.py
+++ b/src/hledger_textual/screens/custom_report_delete_confirm.py
@@ -1,0 +1,21 @@
+"""Delete confirmation modal for custom reports."""
+
+from __future__ import annotations
+
+from hledger_textual.screens.delete_confirm_base import DeleteConfirmBase
+
+
+class CustomReportDeleteConfirmModal(DeleteConfirmBase):
+    """A modal dialog to confirm custom report deletion."""
+
+    def __init__(self, name: str) -> None:
+        """Initialize the modal.
+
+        Args:
+            name: The custom report name to confirm deletion of.
+        """
+        super().__init__(
+            title="Delete Custom Report?",
+            summary=name,
+            prefix="custom-report-delete",
+        )

--- a/src/hledger_textual/screens/custom_report_form.py
+++ b/src/hledger_textual/screens/custom_report_form.py
@@ -1,0 +1,112 @@
+"""Custom report form modal for creating and editing custom hledger reports."""
+
+from __future__ import annotations
+
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, OptionList, Static
+from textual.widgets.option_list import Option
+
+from hledger_textual.models import CustomReport
+
+_EXAMPLES: list[tuple[str, str]] = [
+    ("balance --tree", "Full balance tree"),
+    ("balance expenses --tree", "Expenses tree"),
+    ("balance expenses --tree -M", "Monthly expenses tree"),
+    ("balance income --tree", "Income tree"),
+    ("balance assets --tree", "Assets tree"),
+    ("register expenses -M", "Monthly expense register"),
+    ("register income -M", "Monthly income register"),
+    ("incomestatement -M", "Monthly income statement"),
+    ("balancesheet", "Balance sheet"),
+]
+
+
+class CustomReportFormScreen(ModalScreen[CustomReport | None]):
+    """Centered modal form for creating or editing a custom report."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, report: CustomReport | None = None) -> None:
+        """Initialize the form modal.
+
+        Args:
+            report: Existing custom report to edit, or None for new.
+        """
+        super().__init__()
+        self.report = report
+
+    @property
+    def is_edit(self) -> bool:
+        """Whether this form is editing an existing report."""
+        return self.report is not None
+
+    def compose(self) -> ComposeResult:
+        """Create the modal form layout."""
+        title = "Edit Custom Report" if self.is_edit else "New Custom Report"
+
+        with Vertical(id="custom-report-form-dialog"):
+            yield Static(title, id="custom-report-form-title")
+
+            with Horizontal(classes="form-field"):
+                yield Label("Name:")
+                yield Input(
+                    value=self.report.name if self.is_edit else "",
+                    placeholder="e.g. Monthly expenses tree",
+                    id="custom-report-input-name",
+                )
+
+            with Horizontal(classes="form-field"):
+                yield Label("Command:")
+                yield Input(
+                    value=self.report.command if self.is_edit else "",
+                    placeholder="e.g. balance expenses --tree -M",
+                    id="custom-report-input-command",
+                )
+
+            yield Label("Examples (click to fill command):", id="custom-report-examples-label")
+            yield OptionList(
+                *[Option(f"{cmd}  [{desc}]", id=cmd) for cmd, desc in _EXAMPLES],
+                id="custom-report-examples",
+            )
+
+            with Horizontal(id="custom-report-form-buttons"):
+                yield Button("Cancel", variant="default", id="btn-custom-report-cancel")
+                yield Button("Save", variant="primary", id="btn-custom-report-save")
+
+    @on(OptionList.OptionSelected, "#custom-report-examples")
+    def on_example_selected(self, event: OptionList.OptionSelected) -> None:
+        """Fill the Command input when an example is selected."""
+        if event.option.id:
+            self.query_one("#custom-report-input-command", Input).value = event.option.id
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle button presses."""
+        if event.button.id == "btn-custom-report-save":
+            self._save()
+        elif event.button.id == "btn-custom-report-cancel":
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        """Cancel the form."""
+        self.dismiss(None)
+
+    def _save(self) -> None:
+        """Validate and save the custom report."""
+        name = self.query_one("#custom-report-input-name", Input).value.strip()
+        command = self.query_one("#custom-report-input-command", Input).value.strip()
+
+        if not name:
+            self.notify("Name is required", severity="error", timeout=3)
+            return
+
+        if not command:
+            self.notify("Command is required", severity="error", timeout=3)
+            return
+
+        self.dismiss(CustomReport(name=name, command=command))

--- a/src/hledger_textual/styles/app.tcss
+++ b/src/hledger_textual/styles/app.tcss
@@ -344,14 +344,16 @@ AccountNoteModal {
 
 DeleteConfirmModal,
 BudgetDeleteConfirmModal,
-RecurringDeleteConfirmModal {
+RecurringDeleteConfirmModal,
+CustomReportDeleteConfirmModal {
     align: center middle;
     background: $surface 60%;
 }
 
 #delete-dialog,
 #budget-delete-dialog,
-#recurring-delete-dialog {
+#recurring-delete-dialog,
+#custom-report-delete-dialog {
     width: 60;
     height: auto;
     max-height: 20;
@@ -362,7 +364,8 @@ RecurringDeleteConfirmModal {
 
 #delete-title,
 #budget-delete-title,
-#recurring-delete-title {
+#recurring-delete-title,
+#custom-report-delete-title {
     text-style: bold;
     color: $error;
     width: 100%;
@@ -372,27 +375,31 @@ RecurringDeleteConfirmModal {
 
 #delete-summary,
 #budget-delete-summary,
-#recurring-delete-summary {
+#recurring-delete-summary,
+#custom-report-delete-summary {
     margin-bottom: 1;
     height: auto;
 }
 
 #delete-buttons,
 #budget-delete-buttons,
-#recurring-delete-buttons {
+#recurring-delete-buttons,
+#custom-report-delete-buttons {
     height: 3;
     align: right middle;
 }
 
 #delete-buttons Button,
 #budget-delete-buttons Button,
-#recurring-delete-buttons Button {
+#recurring-delete-buttons Button,
+#custom-report-delete-buttons Button {
     width: 1fr;
 }
 
 #btn-delete,
 #btn-budget-delete,
-#btn-recurring-delete {
+#btn-recurring-delete,
+#btn-custom-report-delete {
     background: $error;
 }
 
@@ -615,6 +622,13 @@ PaneToolbar Select {
     margin-right: 2;
 }
 
+#report-context-bar {
+    height: 1;
+    padding: 0 1;
+    margin-bottom: 1;
+    color: $text;
+}
+
 #reports-table {
     height: 1fr;
 }
@@ -627,6 +641,64 @@ PaneToolbar Select {
 
 #report-chart.visible {
     display: block;
+}
+
+#custom-report-output {
+    display: none;
+    height: 1fr;
+    padding: 1 3;
+    background: $boost;
+}
+
+#custom-report-text {
+    width: auto;
+}
+
+/* --- Custom Report Form --- */
+
+CustomReportFormScreen {
+    align: center middle;
+    background: $surface 60%;
+}
+
+#custom-report-form-dialog {
+    width: 72;
+    max-width: 90%;
+    height: auto;
+    max-height: 80%;
+    border: thick $accent;
+    background: $surface;
+    padding: 1 2;
+}
+
+#custom-report-form-title {
+    text-style: bold;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 1;
+    color: $accent;
+}
+
+#custom-report-examples-label {
+    margin-top: 1;
+    color: $text-muted;
+}
+
+#custom-report-examples {
+    height: 9;
+    margin-top: 0;
+}
+
+#custom-report-form-buttons {
+    height: 3;
+    layout: horizontal;
+    align: right middle;
+    padding: 0 1;
+    margin-top: 1;
+}
+
+#custom-report-form-buttons Button {
+    width: 1fr;
 }
 
 /* --- About Modal --- */

--- a/src/hledger_textual/widgets/reports_pane.py
+++ b/src/hledger_textual/widgets/reports_pane.py
@@ -2,26 +2,39 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date
 from pathlib import Path
 
 from textual import on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal
+from textual.containers import Horizontal, VerticalScroll
+from textual.message import Message
 from textual.widget import Widget
 from rich.text import Text
-from textual.widgets import DataTable, Select
+from textual.widgets import DataTable, Select, Static
 
 from hledger_textual.cache import HledgerCache
-from hledger_textual.config import load_default_commodity
-from hledger_textual.hledger import HledgerError, load_investment_report, load_report
-from hledger_textual.models import ReportData, ReportRow
+from hledger_textual.config import (
+    delete_custom_report,
+    load_custom_reports,
+    load_default_commodity,
+    save_custom_report,
+)
+from hledger_textual.hledger import HledgerError, load_investment_report, load_report, run_custom_report
+from hledger_textual.models import CustomReport, ReportData, ReportRow
 from hledger_textual.widgets import distribute_column_widths
 from hledger_textual.widgets.formatting import fmt_amount_str
 from hledger_textual.widgets.pane_mixin import DataTablePaneMixin
 from hledger_textual.widgets.pane_toolbar import PaneToolbar
 from hledger_textual.widgets.report_chart import ReportChart, extract_chart_data
+
+_ONLY_SEPS = re.compile(r'^[\s=\-\+\|]+$')
+_STANDALONE_ZERO = re.compile(r'(?<![\d.])0(?![\d.])')
+
+_REPORT_LABELS = {"is": "Income Statement", "bs": "Balance Sheet", "cf": "Cash Flow"}
+_PERIOD_LABELS = {3: "3 months", 6: "6 months", 12: "12 months", 0: "Year to date"}
 
 _REPORT_TYPES = [
     ("Income Statement", "is"),
@@ -37,6 +50,74 @@ _PERIOD_RANGES = [
 ]
 
 
+def _format_custom_output(raw: str, *, skip_title: bool = False) -> Text:
+    """Apply Rich styling to raw hledger text output.
+
+    Improvements applied:
+
+    - ``||`` and ``++`` replaced with Unicode box-drawing characters (``│`` / ``┼``)
+    - Separator lines (``===`` / ``---``) are dimmed
+    - Standalone zero values are dimmed
+    - The report title (first non-empty line) is rendered bold, unless
+      ``skip_title`` is ``True`` in which case it is omitted entirely
+    - Total rows (lines after the ``---`` separator) are rendered bold yellow
+
+    Args:
+        raw: Raw stdout string from hledger.
+        skip_title: When ``True``, the first non-empty line (the hledger-generated
+            title) is dropped from the output.  Use this when the report name is
+            already displayed in a separate header widget.
+
+    Returns:
+        A :class:`rich.text.Text` ready for use in a :class:`~textual.widgets.Static`.
+    """
+    result = Text(no_wrap=False)
+    lines = raw.splitlines()
+    after_total_sep = False
+    title_done = False
+
+    for line in lines:
+        display = line.replace('++', '┼').replace('||', '│')
+
+        # Title: first non-empty line
+        if not title_done:
+            if display.strip():
+                title_done = True
+                if not skip_title:
+                    result.append(display + "\n", style="bold")
+            else:
+                if not skip_title:
+                    result.append("\n")
+            continue
+
+        # Separator lines: only =, -, +, |, and spaces
+        if _ONLY_SEPS.match(line):
+            if line.strip() and '-' in line and '=' not in line:
+                after_total_sep = True
+            result.append(display + "\n", style="dim")
+            continue
+
+        # Total rows (after the --- separator)
+        if after_total_sep:
+            result.append(display + "\n", style="bold yellow")
+            continue
+
+        # Regular data line: dim standalone zero values
+        line_text = Text(no_wrap=False)
+        pos = 0
+        for m in _STANDALONE_ZERO.finditer(display):
+            if m.start() > pos:
+                line_text.append(display[pos:m.start()])
+            line_text.append("0", style="dim")
+            pos = m.end()
+        if pos < len(display):
+            line_text.append(display[pos:])
+        line_text.append("\n")
+        result.append_text(line_text)
+
+    return result
+
+
 def _merge_investments(is_data: ReportData, inv_data: ReportData) -> ReportData:
     """Append investment rows as a new section to an Income Statement report.
 
@@ -49,7 +130,6 @@ def _merge_investments(is_data: ReportData, inv_data: ReportData) -> ReportData:
     """
     merged_rows = list(is_data.rows)
 
-    # Add "Investments" section header
     n_periods = len(is_data.period_headers)
     merged_rows.append(ReportRow(
         account="Investments",
@@ -57,10 +137,6 @@ def _merge_investments(is_data: ReportData, inv_data: ReportData) -> ReportData:
         is_section_header=True,
     ))
 
-    # Add data rows only (skip section headers and totals): each leaf account
-    # (XEON, XDWD, XGDU) is already its own row, so the Total row is redundant
-    # and confusing when it concatenates multiple commodities in a single cell.
-    # Strip the common "assets:investments:" prefix to show only the leaf name.
     for row in inv_data.rows:
         if not row.is_section_header and not row.is_total:
             account = row.account
@@ -83,11 +159,31 @@ class ReportsPane(DataTablePaneMixin, Widget):
 
     _main_table_id = "reports-table"
 
+    class CustomReportStateChanged(Message):
+        """Posted when switching between built-in and custom report modes.
+
+        The ``active`` attribute is ``True`` when a custom report is now
+        displayed, ``False`` when returning to a built-in report.
+        """
+
+        def __init__(self, active: bool) -> None:
+            """Initialise the message.
+
+            Args:
+                active: Whether a custom report is now active.
+            """
+            super().__init__()
+            self.active = active
+
     BINDINGS = [
         Binding("r", "refresh", "Refresh", show=True, priority=True),
         Binding("c", "toggle_chart", "Chart", show=False, priority=True),
         Binding("i", "toggle_investments", "Investments", show=False, priority=True),
         Binding("x", "export", "Export", show=False, priority=True),
+        Binding("n", "new_custom_report", "New report", show=True, priority=True),
+        Binding("e", "edit_custom_report", "Edit report", show=False, priority=True),
+        Binding("d", "delete_custom_report", "Delete report", show=False, priority=True),
+        Binding("escape", "back_to_builtin", "Back", show=False),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
     ]
@@ -107,6 +203,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
         self._report_data: ReportData | None = None
         self._fixed_widths: dict[int, int] = {}
         self._show_investments: bool = False
+        self._custom_report_name: str | None = None
 
     def compose(self) -> ComposeResult:
         """Create the pane layout."""
@@ -123,14 +220,25 @@ class ReportsPane(DataTablePaneMixin, Widget):
                 id="report-period-select",
                 allow_blank=False,
             )
+            yield Select(
+                [],
+                prompt="Custom reports…",
+                id="custom-report-select",
+                allow_blank=True,
+            )
 
+        yield Static("", id="report-context-bar")
         yield DataTable(id="reports-table")
         yield ReportChart(id="report-chart")
+        with VerticalScroll(id="custom-report-output"):
+            yield Static("", id="custom-report-text")
 
     def on_mount(self) -> None:
         """Set up the DataTable and load report data."""
         table = self.query_one("#reports-table", DataTable)
         table.cursor_type = "row"
+        self._refresh_custom_report_select()
+        self._update_context_bar_builtin()
         self._load_report_data()
 
     def on_resize(self) -> None:
@@ -139,6 +247,83 @@ class ReportsPane(DataTablePaneMixin, Widget):
             table = self.query_one("#reports-table", DataTable)
             distribute_column_widths(table, self._fixed_widths)
 
+    # --- Context bar ---
+
+    def _update_context_bar_builtin(self) -> None:
+        """Refresh the context bar to show the active built-in report and period."""
+        report_name = _REPORT_LABELS.get(self._report_type, self._report_type)
+        period_name = _PERIOD_LABELS.get(self._period_months, "")
+
+        text = Text()
+        text.append(report_name, style="bold")
+        text.append("  ·  ", style="dim")
+        text.append(period_name, style="dim")
+
+        self.query_one("#report-context-bar", Static).update(text)
+
+    def _update_context_bar_custom(self, name: str, command: str) -> None:
+        """Refresh the context bar to show the active custom report name and command.
+
+        Args:
+            name: The custom report name.
+            command: The hledger command string.
+        """
+        text = Text()
+        text.append(name, style="bold")
+        if command:
+            text.append("  ·  ", style="dim")
+            text.append(command, style="dim")
+
+        self.query_one("#report-context-bar", Static).update(text)
+
+    # --- View toggle ---
+
+    def _set_custom_view(self, active: bool) -> None:
+        """Toggle between the built-in report view and the custom report output view.
+
+        When ``active`` is ``True``, the DataTable and period Select are hidden
+        and the raw-output area is shown.  The inverse applies when ``False``.
+        A :class:`CustomReportStateChanged` message is posted so that the app
+        can update the footer accordingly.
+
+        Args:
+            active: ``True`` to show the custom report output; ``False`` for the
+                built-in DataTable view.
+        """
+        table = self.query_one("#reports-table", DataTable)
+        chart = self.query_one("#report-chart", ReportChart)
+        output = self.query_one("#custom-report-output", VerticalScroll)
+        period_select = self.query_one("#report-period-select", Select)
+
+        type_select = self.query_one("#report-type-select", Select)
+
+        table.display = not active
+        output.display = active
+        type_select.display = not active
+        period_select.display = not active
+        if active:
+            chart.display = False
+
+        self.post_message(self.CustomReportStateChanged(active))
+
+    # --- Custom report Select ---
+
+    def _refresh_custom_report_select(self, select_name: str | None = None) -> None:
+        """Reload custom report options in the Select widget.
+
+        Args:
+            select_name: If provided, sets the Select to this report name
+                after refreshing the options.
+        """
+        reports = load_custom_reports()
+        select = self.query_one("#custom-report-select", Select)
+        options = [(name, name) for name in reports]
+        select.set_options(options)
+        if select_name is not None and select_name in reports:
+            select.value = select_name
+
+    # --- Period calculation ---
+
     def _period_range(self) -> tuple[str, str]:
         """Calculate begin and end dates based on the selected period range.
 
@@ -146,17 +331,14 @@ class ReportsPane(DataTablePaneMixin, Widget):
             A ``(begin, end)`` tuple of date strings in ``YYYY-MM-DD`` format.
         """
         today = date.today()
-        # End: first day of next month
         if today.month == 12:
             end = date(today.year + 1, 1, 1)
         else:
             end = date(today.year, today.month + 1, 1)
 
         if self._period_months == 0:
-            # Year to date
             begin = date(today.year, 1, 1)
         else:
-            # Go back N months
             month = today.month - self._period_months + 1
             year = today.year
             while month < 1:
@@ -166,9 +348,11 @@ class ReportsPane(DataTablePaneMixin, Widget):
 
         return begin.isoformat(), end.isoformat()
 
+    # --- Workers ---
+
     @work(thread=True, exclusive=True, group="reports-load")
     def _load_report_data(self) -> None:
-        """Load report data in a background thread."""
+        """Load built-in report data in a background thread."""
         begin, end = self._period_range()
         commodity = load_default_commodity()
 
@@ -203,6 +387,44 @@ class ReportsPane(DataTablePaneMixin, Widget):
         self._report_data = data
         self.app.call_from_thread(self._apply_report)
 
+    @work(thread=True, exclusive=True, group="reports-load")
+    def _load_custom_report_data(self) -> None:
+        """Load custom report output in a background thread."""
+        if self._custom_report_name is None:
+            return
+
+        reports = load_custom_reports()
+        command = reports.get(self._custom_report_name)
+        if command is None:
+            return
+
+        try:
+            output = run_custom_report(self.journal_file, command)
+        except HledgerError as exc:
+            self.app.call_from_thread(
+                self.notify, str(exc), severity="error", timeout=8
+            )
+            output = f"Error: {exc}"
+
+        self.app.call_from_thread(self._apply_custom_output, output, command)
+
+    # --- Apply methods ---
+
+    def _apply_custom_output(self, output: str, command: str) -> None:
+        """Display custom report output with Rich styling.
+
+        The hledger-generated title line is suppressed because the report name
+        is already shown in the context bar.
+
+        Args:
+            output: The raw text returned by hledger.
+            command: The command used, forwarded to the context bar.
+        """
+        static = self.query_one("#custom-report-text", Static)
+        static.update(_format_custom_output(output.rstrip(), skip_title=True))
+        if self._custom_report_name:
+            self._update_context_bar_custom(self._custom_report_name, command)
+
     def _apply_report(self) -> None:
         """Apply loaded report data to the DataTable."""
         table = self.query_one("#reports-table", DataTable)
@@ -211,9 +433,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
         if data is None:
             return
 
-        # Rebuild columns
         table.clear(columns=True)
-
         table.add_column("Account", key="account")
         self._fixed_widths = {}
         for i, header in enumerate(data.period_headers):
@@ -221,7 +441,6 @@ class ReportsPane(DataTablePaneMixin, Widget):
             table.add_column(header, key=f"period-{i}")
             self._fixed_widths[col_idx] = 18
 
-        # Populate rows with blank separator lines between groups
         n_cols = len(data.period_headers) + 1
         empty_row = [""] * n_cols
 
@@ -250,16 +469,15 @@ class ReportsPane(DataTablePaneMixin, Widget):
                 else:
                     cells.append(formatted)
 
-            # Pad if amounts are fewer than period columns
             while len(cells) < len(data.period_headers) + 1:
                 cells.append("")
 
             table.add_row(*cells)
 
-        # Distribute widths
         if self._fixed_widths:
             distribute_column_widths(table, self._fixed_widths)
 
+        self._update_context_bar_builtin()
         self._update_chart()
 
     def _update_chart(self) -> None:
@@ -272,11 +490,15 @@ class ReportsPane(DataTablePaneMixin, Widget):
 
     def action_toggle_chart(self) -> None:
         """Toggle chart visibility."""
+        if self._custom_report_name is not None:
+            return
         chart = self.query_one("#report-chart", ReportChart)
         chart.toggle_class("visible")
 
     def action_toggle_investments(self) -> None:
         """Toggle the Investments section on the Income Statement."""
+        if self._custom_report_name is not None:
+            return
         self._show_investments = not self._show_investments
         label = "Investments shown" if self._show_investments else "Investments hidden"
         self.notify(label, timeout=2)
@@ -284,8 +506,86 @@ class ReportsPane(DataTablePaneMixin, Widget):
 
     def action_refresh(self) -> None:
         """Reload report data."""
-        self._load_report_data()
+        if self._custom_report_name is not None:
+            self._load_custom_report_data()
+        else:
+            self._load_report_data()
         self.notify("Refreshed", timeout=2)
+
+    def action_new_custom_report(self) -> None:
+        """Open the form to create a new custom report."""
+        from hledger_textual.screens.custom_report_form import CustomReportFormScreen
+
+        def _on_result(report: CustomReport | None) -> None:
+            if report is None:
+                return
+            save_custom_report(report.name, report.command)
+            self._custom_report_name = report.name
+            self._refresh_custom_report_select(select_name=report.name)
+            self._set_custom_view(active=True)
+            self._load_custom_report_data()
+
+        self.app.push_screen(CustomReportFormScreen(), _on_result)
+
+    def action_edit_custom_report(self) -> None:
+        """Open the form to edit the currently selected custom report."""
+        if self._custom_report_name is None:
+            self.notify("No custom report selected", severity="warning", timeout=3)
+            return
+
+        from hledger_textual.screens.custom_report_form import CustomReportFormScreen
+
+        reports = load_custom_reports()
+        command = reports.get(self._custom_report_name, "")
+        old_name = self._custom_report_name
+        report = CustomReport(name=old_name, command=command)
+
+        def _on_result(updated: CustomReport | None) -> None:
+            if updated is None:
+                return
+            if updated.name != old_name:
+                delete_custom_report(old_name)
+            save_custom_report(updated.name, updated.command)
+            self._custom_report_name = updated.name
+            self._refresh_custom_report_select(select_name=updated.name)
+            self._update_context_bar_custom(updated.name, updated.command)
+            self._load_custom_report_data()
+
+        self.app.push_screen(CustomReportFormScreen(report=report), _on_result)
+
+    def action_delete_custom_report(self) -> None:
+        """Open a confirmation dialog to delete the currently selected custom report."""
+        if self._custom_report_name is None:
+            self.notify("No custom report selected", severity="warning", timeout=3)
+            return
+
+        from hledger_textual.screens.custom_report_delete_confirm import (
+            CustomReportDeleteConfirmModal,
+        )
+
+        name = self._custom_report_name
+
+        def _on_result(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            delete_custom_report(name)
+            self._custom_report_name = None
+            self._refresh_custom_report_select()
+            self._set_custom_view(active=False)
+            self._update_context_bar_builtin()
+            self._load_report_data()
+
+        self.app.push_screen(CustomReportDeleteConfirmModal(name), _on_result)
+
+    def action_back_to_builtin(self) -> None:
+        """Return from custom report view to the built-in report view."""
+        if self._custom_report_name is None:
+            return
+        self._custom_report_name = None
+        self.query_one("#custom-report-select", Select).clear()
+        self._set_custom_view(active=False)
+        self._update_context_bar_builtin()
+        self._load_report_data()
 
     # --- Event handlers ---
 
@@ -294,7 +594,36 @@ class ReportsPane(DataTablePaneMixin, Widget):
         """Reload when the report type changes."""
         if event.value is not Select.BLANK:
             self._report_type = event.value
+            if self._custom_report_name is not None:
+                self._custom_report_name = None
+                self.query_one("#custom-report-select", Select).clear()
+                self._set_custom_view(active=False)
+            self._update_context_bar_builtin()
             self._load_report_data()
+
+    @on(Select.Changed, "#report-period-select")
+    def on_period_range_changed(self, event: Select.Changed) -> None:
+        """Reload when the period range changes."""
+        if event.value is not Select.BLANK:
+            self._period_months = event.value
+            if self._custom_report_name is None:
+                self._update_context_bar_builtin()
+                self._load_report_data()
+
+    @on(Select.Changed, "#custom-report-select")
+    def on_custom_report_changed(self, event: Select.Changed) -> None:
+        """Load and display the selected custom report."""
+        if event.value is Select.BLANK:
+            self._custom_report_name = None
+            self._set_custom_view(active=False)
+            self._update_context_bar_builtin()
+            return
+        self._custom_report_name = str(event.value)
+        reports = load_custom_reports()
+        command = reports.get(self._custom_report_name, "")
+        self._update_context_bar_custom(self._custom_report_name, command)
+        self._set_custom_view(active=True)
+        self._load_custom_report_data()
 
     def get_export_data(self):
         """Return an ExportData with report rows for export.
@@ -319,12 +648,10 @@ class ReportsPane(DataTablePaneMixin, Widget):
         for row in data.rows:
             cells = [row.account]
             cells.extend(row.amounts)
-            # Pad if amounts are fewer than period columns
             while len(cells) < len(headers):
                 cells.append("")
             rows.append(cells)
 
-        # Determine report type label
         type_labels = {"is": "Income Statement", "bs": "Balance Sheet", "cf": "Cash Flow"}
         type_label = type_labels.get(self._report_type, self._report_type)
 
@@ -334,10 +661,3 @@ class ReportsPane(DataTablePaneMixin, Widget):
             rows=rows,
             pane_name="report",
         )
-
-    @on(Select.Changed, "#report-period-select")
-    def on_period_range_changed(self, event: Select.Changed) -> None:
-        """Reload when the period range changes."""
-        if event.value is not Select.BLANK:
-            self._period_months = event.value
-            self._load_report_data()

--- a/tests/test_custom_reports.py
+++ b/tests/test_custom_reports.py
@@ -1,0 +1,373 @@
+"""Tests for custom report CRUD (config) and hledger execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hledger_textual.config import (
+    delete_custom_report,
+    load_custom_reports,
+    save_custom_report,
+    save_theme,
+)
+from hledger_textual.hledger import HledgerError, run_custom_report
+from hledger_textual.models import CustomReport
+
+
+# ---------------------------------------------------------------------------
+# Config CRUD tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCustomReports:
+    """Tests for load_custom_reports."""
+
+    def test_returns_empty_when_no_section(self, tmp_path, monkeypatch):
+        """Returns an empty dict when config.toml has no [custom_reports] section."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('theme = "nord"\n')
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        assert load_custom_reports() == {}
+
+    def test_returns_empty_when_config_missing(self, tmp_path, monkeypatch):
+        """Returns an empty dict when the config file does not exist."""
+        monkeypatch.setattr(
+            "hledger_textual.config._CONFIG_PATH", tmp_path / "nonexistent.toml"
+        )
+        assert load_custom_reports() == {}
+
+    def test_returns_reports_from_config(self, tmp_path, monkeypatch):
+        """Returns the name-to-command mapping from the [custom_reports] section."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            '[custom_reports]\n'
+            '"Monthly expenses" = "balance expenses --tree -M"\n'
+            '"Salary" = "register income:salary"\n'
+        )
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        result = load_custom_reports()
+        assert result == {
+            "Monthly expenses": "balance expenses --tree -M",
+            "Salary": "register income:salary",
+        }
+
+
+class TestSaveCustomReport:
+    """Tests for save_custom_report."""
+
+    def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
+        """save_custom_report persists a report that load_custom_reports retrieves."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_custom_report("My report", "balance expenses --tree")
+        result = load_custom_reports()
+        assert result == {"My report": "balance expenses --tree"}
+
+    def test_save_multiple_reports(self, tmp_path, monkeypatch):
+        """Multiple custom reports can be saved and all are returned."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_custom_report("Expenses", "balance expenses")
+        save_custom_report("Income", "balance income")
+        result = load_custom_reports()
+        assert result["Expenses"] == "balance expenses"
+        assert result["Income"] == "balance income"
+
+    def test_save_overwrites_existing_name(self, tmp_path, monkeypatch):
+        """Saving with an existing name updates the command."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_custom_report("Report", "balance expenses")
+        save_custom_report("Report", "balance income --tree")
+        assert load_custom_reports()["Report"] == "balance income --tree"
+
+    def test_preserves_other_settings(self, tmp_path, monkeypatch):
+        """Saving a custom report does not corrupt other config sections."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_theme("nord")
+        save_custom_report("Report", "balance expenses")
+        from hledger_textual.config import load_theme
+        assert load_theme() == "nord"
+        assert load_custom_reports()["Report"] == "balance expenses"
+
+
+class TestDeleteCustomReport:
+    """Tests for delete_custom_report."""
+
+    def test_delete_removes_report(self, tmp_path, monkeypatch):
+        """delete_custom_report removes the named report from config."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_custom_report("A", "balance")
+        save_custom_report("B", "register")
+        delete_custom_report("A")
+        result = load_custom_reports()
+        assert "A" not in result
+        assert result["B"] == "register"
+
+    def test_delete_nonexistent_is_noop(self, tmp_path, monkeypatch):
+        """Deleting a report that does not exist does not raise."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_custom_report("keep", "balance")
+        delete_custom_report("nonexistent")
+        assert load_custom_reports() == {"keep": "balance"}
+
+    def test_delete_preserves_other_sections(self, tmp_path, monkeypatch):
+        """Deleting a custom report does not corrupt other config sections."""
+        config_path = tmp_path / ".config" / "hledger-textual" / "config.toml"
+        monkeypatch.setattr("hledger_textual.config._CONFIG_PATH", config_path)
+        save_theme("gruvbox")
+        save_custom_report("A", "balance")
+        delete_custom_report("A")
+        from hledger_textual.config import load_theme
+        assert load_theme() == "gruvbox"
+        assert load_custom_reports() == {}
+
+
+# ---------------------------------------------------------------------------
+# CustomReport model tests
+# ---------------------------------------------------------------------------
+
+
+class TestCustomReportModel:
+    """Tests for the CustomReport dataclass."""
+
+    def test_fields(self):
+        """CustomReport stores name and command."""
+        r = CustomReport(name="My report", command="balance expenses --tree")
+        assert r.name == "My report"
+        assert r.command == "balance expenses --tree"
+
+
+# ---------------------------------------------------------------------------
+# run_custom_report tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCustomReport:
+    """Tests for run_custom_report in hledger.py."""
+
+    def test_passes_args_to_run_hledger(self, tmp_path):
+        """run_custom_report splits the command and calls run_hledger correctly."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("")
+
+        captured: list[tuple] = []
+
+        def _mock_run_hledger(*args, file=None):
+            captured.append((args, file))
+            return "output"
+
+        with patch("hledger_textual.hledger.run_hledger", _mock_run_hledger):
+            result = run_custom_report(journal, "balance expenses --tree")
+
+        assert result == "output"
+        assert len(captured) == 1
+        args, file = captured[0]
+        assert args == ("balance", "expenses", "--tree")
+        assert file == journal
+
+    def test_handles_quoted_args(self, tmp_path):
+        """run_custom_report handles shell-quoted arguments correctly."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("")
+
+        captured: list[tuple] = []
+
+        def _mock_run_hledger(*args, file=None):
+            captured.append((args, file))
+            return ""
+
+        with patch("hledger_textual.hledger.run_hledger", _mock_run_hledger):
+            run_custom_report(journal, 'register "income:freelance work"')
+
+        args, _ = captured[0]
+        assert args == ("register", "income:freelance work")
+
+    def test_propagates_hledger_error(self, tmp_path):
+        """HledgerError raised by run_hledger propagates to the caller."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("")
+
+        def _mock_run_hledger(*args, file=None):
+            raise HledgerError("command failed")
+
+        with patch("hledger_textual.hledger.run_hledger", _mock_run_hledger):
+            with pytest.raises(HledgerError, match="command failed"):
+                run_custom_report(journal, "balance")
+
+
+# ---------------------------------------------------------------------------
+# _format_custom_output tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCustomOutput:
+    """Tests for the _format_custom_output Rich formatter."""
+
+    def _render(self, raw: str) -> str:
+        """Render a Rich Text to a plain string for assertion."""
+        from hledger_textual.widgets.reports_pane import _format_custom_output
+        return _format_custom_output(raw).plain
+
+    def test_replaces_pipe_separators(self):
+        """|| is replaced with the Unicode box-drawing character │."""
+        from hledger_textual.widgets.reports_pane import _format_custom_output
+        raw = "Title\n  Account  ||  Jan\n"
+        plain = _format_custom_output(raw).plain
+        assert "│" in plain
+        assert "||" not in plain
+
+    def test_replaces_plus_plus_separators(self):
+        """++ is replaced with ┼."""
+        from hledger_textual.widgets.reports_pane import _format_custom_output
+        raw = "Title\n=========++==========\n"
+        plain = _format_custom_output(raw).plain
+        assert "┼" in plain
+        assert "++" not in plain
+
+    def test_title_line_is_bold(self):
+        """The first non-empty line is rendered bold."""
+        from rich.text import Text
+        from hledger_textual.widgets.reports_pane import _format_custom_output
+        raw = "Balance changes in 2026Q1:\n  Account  ||  Jan\n"
+        text = _format_custom_output(raw)
+        # Find the span covering the title
+        styles = {span.style for span in text._spans}
+        assert any("bold" in str(s) for s in styles)
+
+    def test_total_rows_after_dashes(self):
+        """Lines after the --- separator are styled bold yellow."""
+        from hledger_textual.widgets.reports_pane import _format_custom_output
+        raw = (
+            "Title\n"
+            "  Expenses  ||  €100\n"
+            "------------++---------\n"
+            "            ||  €100\n"
+        )
+        text = _format_custom_output(raw)
+        styles = {str(span.style) for span in text._spans}
+        assert any("yellow" in s for s in styles)
+
+    def test_standalone_zeros_are_dimmed(self):
+        """Standalone 0 values are dimmed; 0 inside amounts like €0.50 is not."""
+        from hledger_textual.widgets.reports_pane import _format_custom_output
+        raw = "Title\n  Accounting  ||        0   €36.50\n"
+        text = _format_custom_output(raw)
+        # There should be a dim span; the plain text retains the 0
+        assert "0" in text.plain
+        dim_spans = [s for s in text._spans if "dim" in str(s.style)]
+        assert len(dim_spans) > 0
+
+
+# ---------------------------------------------------------------------------
+# ReportsPane integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportsPaneCustomReports:
+    """Integration tests for custom report selection in ReportsPane."""
+
+    async def test_custom_report_select_is_present(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The custom-report-select widget is mounted in ReportsPane."""
+        from textual.app import App, ComposeResult
+        from textual.widgets import Select
+        from hledger_textual.models import ReportData
+        from hledger_textual.widgets.reports_pane import ReportsPane
+
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report",
+            lambda *a, **kw: ReportData(title="", period_headers=[], rows=[]),
+        )
+
+        journal = tmp_path / "test.journal"
+        journal.write_text("")
+
+        class _App(App):
+            def compose(self) -> ComposeResult:
+                yield ReportsPane(journal)
+
+        app = _App()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            select = app.query_one("#custom-report-select", Select)
+            assert select is not None
+
+    async def test_selecting_custom_report_shows_output_widget(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Selecting a custom report hides the DataTable and shows the output widget."""
+        from textual.app import App, ComposeResult
+        from textual.containers import VerticalScroll
+        from textual.widgets import DataTable, Select
+        from hledger_textual.models import ReportData
+        from hledger_textual.widgets.reports_pane import ReportsPane
+
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report",
+            lambda *a, **kw: ReportData(title="", period_headers=[], rows=[]),
+        )
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_custom_reports",
+            lambda: {"My report": "balance expenses"},
+        )
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.run_custom_report",
+            lambda *a, **kw: "expenses  €100",
+        )
+
+        journal = tmp_path / "test.journal"
+        journal.write_text("")
+
+        class _App(App):
+            def compose(self) -> ComposeResult:
+                yield ReportsPane(journal)
+
+        app = _App()
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.3)
+            pane = app.query_one(ReportsPane)
+            select = app.query_one("#custom-report-select", Select)
+            select.value = "My report"
+            await pilot.pause(delay=0.3)
+            table = app.query_one("#reports-table", DataTable)
+            output = app.query_one("#custom-report-output", VerticalScroll)
+            assert not table.display
+            assert output.display
+
+    async def test_n_key_opens_custom_report_form(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Pressing n opens the CustomReportFormScreen."""
+        from textual.app import App, ComposeResult
+        from hledger_textual.models import ReportData
+        from hledger_textual.screens.custom_report_form import CustomReportFormScreen
+        from hledger_textual.widgets.reports_pane import ReportsPane
+
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report",
+            lambda *a, **kw: ReportData(title="", period_headers=[], rows=[]),
+        )
+
+        journal = tmp_path / "test.journal"
+        journal.write_text("")
+
+        class _App(App):
+            def compose(self) -> ComposeResult:
+                yield ReportsPane(journal)
+
+        app = _App()
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.3)
+            pane = app.query_one(ReportsPane)
+            pane.focus()
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(app.screen, CustomReportFormScreen)


### PR DESCRIPTION
Users can now define named hledger report commands and run them directly from the Reports tab (tab 5).

- config.py: load/save/delete_custom_report persisted in [custom_reports] section of config.toml
- models.py: CustomReport dataclass (name + command)
- hledger.py: run_custom_report() splits command with shlex and runs hledger
- screens/custom_report_form.py: modal form with Name + Command fields and a clickable OptionList of common hledger report examples
- screens/custom_report_delete_confirm.py: delete confirmation modal
- widgets/reports_pane.py:
  - Custom reports Select in toolbar; built-in selects hidden in custom mode
  - VerticalScroll output area with Rich-styled text (box-drawing chars, dim zeros, bold title suppressed, bold-yellow totals)
  - Context bar showing active report name · command or period
  - CustomReportStateChanged message drives dynamic footer in app.py
  - [n] new, [e] edit, [d] delete, [esc] back to built-in, [r] refresh
- app.py: separate footer strings for built-in vs custom report mode
- styles/app.tcss: styles for context bar, output area, form dialog, delete confirm dialog
- tests/test_custom_reports.py: 22 tests covering config CRUD, run_custom_report, _format_custom_output, and ReportsPane integration