### PR TITLE
release: v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.1.19"
+version = "0.2.0"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

- chore: bump version to 0.2.0

Skips v0.1.19 (PyPI publish failed due to GitHub immutable release tag restriction).

## Milestone

Closes milestone: v0.2.0