### PR TITLE
feat: Windows installer pipeline (experimental)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,123 @@
+name: Build Windows Installer
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g. v0.2.1)"
+        required: false
+        default: "dev"
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    permissions:
+      contents: write  # needed to upload release assets
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            echo "version_bare=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "version_bare=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies + PyInstaller
+        run: uv sync --group dev && uv pip install pyinstaller
+
+      - name: Build with PyInstaller
+        run: uv run pyinstaller hledger-textual.spec --noconfirm
+
+      # ----------------------------------------------------------------
+      # Download the latest hledger Windows binary from the hledger repo
+      # ----------------------------------------------------------------
+      - name: Download hledger Windows binary
+        shell: pwsh
+        run: |
+          $release = Invoke-RestMethod `
+            -Uri "https://api.github.com/repos/simonmichael/hledger/releases/latest" `
+            -Headers @{ "User-Agent" = "hledger-textual-ci" }
+          $asset = $release.assets | Where-Object {
+            $_.name -match "windows" -and $_.name -match "x64" -and $_.name -match "\.zip$"
+          } | Select-Object -First 1
+          if (-not $asset) {
+            $asset = $release.assets | Where-Object {
+              $_.name -match "windows" -and $_.name -match "\.zip$"
+            } | Select-Object -First 1
+          }
+          Write-Host "Downloading $($asset.name) ..."
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile hledger-windows.zip
+          Expand-Archive hledger-windows.zip -DestinationPath hledger-bin
+          # Find and copy hledger.exe to workspace root
+          $exe = Get-ChildItem -Path hledger-bin -Recurse -Filter "hledger.exe" | Select-Object -First 1
+          Copy-Item $exe.FullName hledger.exe
+          Write-Host "hledger.exe ready: $(Get-Item hledger.exe | Select-Object -ExpandProperty Length) bytes"
+
+      # ----------------------------------------------------------------
+      # NSIS — bundled installer (includes hledger.exe)
+      # ----------------------------------------------------------------
+      - name: Install NSIS + EnVar plugin
+        shell: pwsh
+        run: |
+          choco install nsis --no-progress -y
+          # Download EnVar plugin for PATH manipulation
+          $pluginDir = "C:\Program Files (x86)\NSIS\Plugins\x86-unicode"
+          Invoke-WebRequest `
+            -Uri "https://nsis.sourceforge.io/mediawiki/images/7/7f/EnVar_plugin.zip" `
+            -OutFile EnVar_plugin.zip
+          Expand-Archive EnVar_plugin.zip -DestinationPath EnVar_plugin
+          $dll = Get-ChildItem -Path EnVar_plugin -Recurse -Filter "EnVar.dll" | Select-Object -First 1
+          Copy-Item $dll.FullName $pluginDir
+
+      - name: Build bundled installer (includes hledger.exe)
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\NSIS\makensis.exe" ^
+            /DAPPVERSION=${{ steps.version.outputs.version_bare }} ^
+            /DBUNDLED_HLEDGER=1 ^
+            installer\windows.nsi
+
+      - name: Build slim installer (hledger not included)
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\NSIS\makensis.exe" ^
+            /DAPPVERSION=${{ steps.version.outputs.version_bare }} ^
+            installer\windows.nsi
+
+      # ----------------------------------------------------------------
+      # Upload both installers as release assets
+      # ----------------------------------------------------------------
+      - name: Upload installers to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version_bare }}"
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "hledger-textual-${VERSION}-windows-x64-bundled.exe" \
+            "hledger-textual-${VERSION}-windows-x64-slim.exe" \
+            --clobber
+
+      - name: Upload installers as workflow artifacts (manual runs)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-installers
+          path: "*.exe"
+          retention-days: 14

--- a/hledger-textual.spec
+++ b/hledger-textual.spec
@@ -1,0 +1,78 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec file for hledger-textual Windows bundle."""
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+# Collect Textual's bundled CSS/assets and plotext data files
+textual_datas = collect_data_files("textual")
+plotext_datas = collect_data_files("textual_plotext")
+babel_datas = collect_data_files("babel")
+
+a = Analysis(
+    ["src/hledger_textual/__main__.py"],
+    pathex=["src"],
+    binaries=[],
+    datas=[
+        # App stylesheet
+        ("src/hledger_textual/styles/app.tcss", "hledger_textual/styles"),
+        # Textual, plotext, and babel bundled data
+        *textual_datas,
+        *plotext_datas,
+        *babel_datas,
+    ],
+    hiddenimports=[
+        # Textual internals loaded dynamically
+        *collect_submodules("textual"),
+        *collect_submodules("textual_plotext"),
+        # Babel locale data
+        *collect_submodules("babel"),
+        # fpdf2
+        "fpdf",
+        "fpdf.fonts",
+        # pricehist (optional — only used when live prices are fetched)
+        "pricehist",
+        # TOML support for Python < 3.11
+        "tomli",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # Keep the bundle lean — test frameworks are never needed at runtime
+        "pytest",
+        "pytest_asyncio",
+    ],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="hledger-textual",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,  # Terminal app — must keep console
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="hledger-textual",
+)

--- a/installer/windows.nsi
+++ b/installer/windows.nsi
@@ -1,0 +1,105 @@
+; hledger-textual Windows Installer
+; Built with NSIS (https://nsis.sourceforge.io)
+;
+; Produces two optional installer flavors via /DBUNDLED_HLEDGER define:
+;   - Full bundle  : includes hledger.exe  (no hledger pre-installation needed)
+;   - Slim bundle  : hledger.exe not included (requires hledger on PATH)
+
+!ifndef APPVERSION
+  !define APPVERSION "0.0.0"
+!endif
+
+!ifndef BUNDLED_HLEDGER
+  !define BUNDLED_HLEDGER 0
+!endif
+
+!if ${BUNDLED_HLEDGER} == 1
+  !define OUTFILE "hledger-textual-${APPVERSION}-windows-x64-bundled.exe"
+  !define PRODUCT_NAME "hledger-textual (bundled)"
+!else
+  !define OUTFILE "hledger-textual-${APPVERSION}-windows-x64-slim.exe"
+  !define PRODUCT_NAME "hledger-textual (slim)"
+!endif
+
+!define INSTDIR_DEFAULT "$PROGRAMFILES64\hledger-textual"
+!define REG_UNINST "Software\Microsoft\Windows\CurrentVersion\Uninstall\hledger-textual"
+
+Name "${PRODUCT_NAME} ${APPVERSION}"
+OutFile "${OUTFILE}"
+InstallDir "${INSTDIR_DEFAULT}"
+InstallDirRegKey HKLM "Software\hledger-textual" "InstallDir"
+RequestExecutionLevel admin
+SetCompressor /SOLID lzma
+
+;------------------------------------------------------------------
+; Pages
+;------------------------------------------------------------------
+!include "MUI2.nsh"
+
+!define MUI_ABORTWARNING
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!define MUI_FINISHPAGE_RUN "$INSTDIR\hledger-textual.exe"
+!define MUI_FINISHPAGE_RUN_TEXT "Launch hledger-textual now"
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+;------------------------------------------------------------------
+; Install section
+;------------------------------------------------------------------
+Section "Install" SecInstall
+  SetOutPath "$INSTDIR"
+
+  ; Copy all PyInstaller output files
+  File /r "dist\hledger-textual\*.*"
+
+  !if ${BUNDLED_HLEDGER} == 1
+    ; Include the bundled hledger.exe
+    File "hledger.exe"
+  !endif
+
+  ; Add install dir to system PATH
+  EnVar::AddValue "PATH" "$INSTDIR"
+
+  ; Write registry keys for uninstaller
+  WriteRegStr HKLM "Software\hledger-textual" "InstallDir" "$INSTDIR"
+  WriteRegStr HKLM "${REG_UNINST}" "DisplayName" "hledger-textual ${APPVERSION}"
+  WriteRegStr HKLM "${REG_UNINST}" "UninstallString" "$INSTDIR\uninstall.exe"
+  WriteRegStr HKLM "${REG_UNINST}" "DisplayVersion" "${APPVERSION}"
+  WriteRegStr HKLM "${REG_UNINST}" "Publisher" "Michele Broggi"
+  WriteRegStr HKLM "${REG_UNINST}" "URLInfoAbout" "https://github.com/thesmokinator/hledger-textual"
+  WriteRegDWORD HKLM "${REG_UNINST}" "NoModify" 1
+  WriteRegDWORD HKLM "${REG_UNINST}" "NoRepair" 1
+
+  ; Start Menu shortcut
+  CreateDirectory "$SMPROGRAMS\hledger-textual"
+  CreateShortcut "$SMPROGRAMS\hledger-textual\hledger-textual.lnk" \
+    "$INSTDIR\hledger-textual.exe" "" "$INSTDIR\hledger-textual.exe"
+  CreateShortcut "$SMPROGRAMS\hledger-textual\Uninstall.lnk" \
+    "$INSTDIR\uninstall.exe"
+
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+SectionEnd
+
+;------------------------------------------------------------------
+; Uninstall section
+;------------------------------------------------------------------
+Section "Uninstall"
+  ; Remove from PATH
+  EnVar::DeleteValue "PATH" "$INSTDIR"
+
+  ; Remove files
+  RMDir /r "$INSTDIR"
+
+  ; Remove Start Menu shortcuts
+  RMDir /r "$SMPROGRAMS\hledger-textual"
+
+  ; Remove registry keys
+  DeleteRegKey HKLM "Software\hledger-textual"
+  DeleteRegKey HKLM "${REG_UNINST}"
+SectionEnd

--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import csv
 import io
 import json
+import os
+import re
 import shlex
+import shutil
 import subprocess
+import sys
 from decimal import Decimal
 from pathlib import Path
-
-import re
 
 from hledger_textual.models import (
     Amount,
@@ -31,6 +33,35 @@ class HledgerError(Exception):
     """Raised when an hledger command fails."""
 
 
+def _get_hledger_cmd() -> str:
+    """Return the hledger executable path.
+
+    Resolution order:
+    1. System hledger found on PATH — respects the user's installed version.
+    2. Bundled ``hledger.exe`` placed next to the app executable (PyInstaller
+       ``--onedir`` builds).
+    3. Bundled ``hledger.exe`` inside the PyInstaller extraction directory
+       (PyInstaller ``--onefile`` builds, via ``sys._MEIPASS``).
+    4. Plain ``"hledger"`` string — will raise ``FileNotFoundError`` at call
+       time if hledger is not installed, producing the usual error message.
+    """
+    if shutil.which("hledger"):
+        return "hledger"
+    if getattr(sys, "frozen", False):
+        exe_name = "hledger.exe" if sys.platform == "win32" else "hledger"
+        # --onedir: hledger sits next to the main executable
+        candidate = Path(sys.executable).parent / exe_name
+        if candidate.exists():
+            return str(candidate)
+        # --onefile: hledger was extracted to the temporary _MEIPASS directory
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            candidate = Path(meipass) / exe_name
+            if candidate.exists():
+                return str(candidate)
+    return "hledger"
+
+
 def run_hledger(*args: str, file: str | Path | None = None) -> str:
     """Run an hledger command and return stdout.
 
@@ -44,7 +75,7 @@ def run_hledger(*args: str, file: str | Path | None = None) -> str:
     Raises:
         HledgerError: If the command fails or hledger is not found.
     """
-    cmd = ["hledger"]
+    cmd = [_get_hledger_cmd()]
     if file is not None:
         cmd.extend(["-f", str(file)])
     cmd.extend(args)


### PR DESCRIPTION
## Summary

Experimental Windows bundle support via PyInstaller + NSIS.

- `_get_hledger_cmd()` in `hledger.py`: resolves hledger executable — system PATH first, then bundled `hledger.exe` fallback (supports both PyInstaller `--onedir` and `--onefile` builds)
- `hledger-textual.spec`: PyInstaller spec bundling CSS, Textual/babel data files
- `installer/windows.nsi`: NSIS script producing two installers:
  - **bundled** — includes `hledger.exe` (standalone, no dependencies)
  - **slim** — requires hledger on PATH
- `.github/workflows/build-windows.yml`: triggered on release publish; downloads latest hledger Windows binary, builds both installers, uploads as release assets. Also supports `workflow_dispatch` for manual testing.

## Status

🧪 Experimental — pipeline not yet tested on a real Windows runner.

## Test plan

- [ ] Trigger `workflow_dispatch` on main and verify the pipeline completes
- [ ] Verify bundled installer works on a clean Windows machine
- [ ] Verify slim installer works when hledger is on PATH