### PR TITLE
fix: handle thousands separators in amount parsing (closes #81)

### DIFF
--- a/src/hledger_textual/amountutil.py
+++ b/src/hledger_textual/amountutil.py
@@ -22,21 +22,21 @@ def parse_amount_string(s: str) -> tuple[Decimal, str]:
     if not s:
         raise ValueError("Empty amount string")
 
-    # Try left-side commodity: €800.00 or $500
-    match = re.match(r"^([^\d\s.-]+)\s*(-?[\d.]+)$", s)
+    # Try left-side commodity: €800.00, $500, $1,320.28
+    match = re.match(r"^([^\d\s.,-]+)\s*(-?[\d,.]+)$", s)
     if match:
         commodity = match.group(1)
         try:
-            quantity = Decimal(match.group(2))
+            quantity = Decimal(match.group(2).replace(",", ""))
         except InvalidOperation:
             raise ValueError(f"Invalid amount: {s}")
         return quantity, commodity
 
-    # Try right-side commodity: 800.00 EUR
-    match = re.match(r"^(-?[\d.]+)\s*([^\d\s.-]+)$", s)
+    # Try right-side commodity: 800.00 EUR, 1,320.28 EUR
+    match = re.match(r"^(-?[\d,.]+)\s*([^\d\s.,-]+)$", s)
     if match:
         try:
-            quantity = Decimal(match.group(1))
+            quantity = Decimal(match.group(1).replace(",", ""))
         except InvalidOperation:
             raise ValueError(f"Invalid amount: {s}")
         commodity = match.group(2)

--- a/tests/test_amountutil.py
+++ b/tests/test_amountutil.py
@@ -42,6 +42,30 @@ class TestParseAmountString:
         assert qty == Decimal("100.00")
         assert commodity == "€"
 
+    def test_left_commodity_with_thousands_separator(self):
+        """Parse amount with left-side commodity and thousands separator."""
+        qty, commodity = parse_amount_string("$1,320.28")
+        assert qty == Decimal("1320.28")
+        assert commodity == "$"
+
+    def test_left_commodity_negative_with_thousands_separator(self):
+        """Parse negative amount with left-side commodity and thousands separator."""
+        qty, commodity = parse_amount_string("$-1,536.75")
+        assert qty == Decimal("-1536.75")
+        assert commodity == "$"
+
+    def test_right_commodity_with_thousands_separator(self):
+        """Parse amount with right-side commodity and thousands separator."""
+        qty, commodity = parse_amount_string("1,320.28EUR")
+        assert qty == Decimal("1320.28")
+        assert commodity == "EUR"
+
+    def test_large_amount_with_thousands_separators(self):
+        """Parse large amount with multiple thousands separators."""
+        qty, commodity = parse_amount_string("€1,000,000.00")
+        assert qty == Decimal("1000000.00")
+        assert commodity == "€"
+
     def test_empty_raises(self):
         """Empty string raises ValueError."""
         with pytest.raises(ValueError):

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -185,6 +185,26 @@ class TestParseRecurringRules:
         assert len(rules) == 1
         assert rules[0].end_date == "2026-12-31"
 
+    def test_postings_with_thousands_separator(self, tmp_path: Path):
+        """Amounts with thousands separators (commas) are parsed correctly."""
+        content = (
+            "~ monthly from 2026-05-01  ; rule-id:mortgage-001 Mortgage\n"
+            "    expenses:mortgage:interest              $1,320.28\n"
+            "    liabilities:property:mortgage            216.47\n"
+            "    assets:operating                        $-1,536.75\n"
+        )
+        f = tmp_path / "recurring.journal"
+        f.write_text(content)
+        rules = parse_recurring_rules(f)
+        assert len(rules) == 1
+        rule = rules[0]
+        assert len(rule.postings) == 3
+        assert rule.postings[0].account == "expenses:mortgage:interest"
+        assert rule.postings[0].amounts[0].quantity == Decimal("1320.28")
+        assert rule.postings[0].amounts[0].commodity == "$"
+        assert rule.postings[2].account == "assets:operating"
+        assert rule.postings[2].amounts[0].quantity == Decimal("-1536.75")
+
     def test_roundtrip(self, sample_recurring_path: Path, tmp_path: Path):
         """Parse then format then re-parse produces identical results."""
         rules = parse_recurring_rules(sample_recurring_path)


### PR DESCRIPTION
## Summary
- Fix `parse_amount_string()` regex patterns to accept commas as digit group separators (e.g. `$1,320.28`, `€1,000,000.00`)
- Strip commas before `Decimal` conversion so amounts parse correctly in both recurring and budget modules
- Add tests for left/right commodity with thousands separators, negative amounts, and full recurring rule integration

## Test plan
- [x] 89/89 existing + new tests pass
- [x] Manual verification: recurring rule with `$1,320.28` amounts now shows correctly in edit form
- [x] Save after editing no longer produces hledger validation error

Closes #81