### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.2.1"
+version = "0.2.2"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 for release

Part of v0.2.2 milestone.