### PR TITLE
Release v0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.2.2"
+version = "0.2.3"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [

--- a/src/hledger_textual/screens/account_transactions.py
+++ b/src/hledger_textual/screens/account_transactions.py
@@ -127,6 +127,12 @@ class AccountTransactionsScreen(Screen):
             AccountNoteModal(self.account, current_note), callback=on_result
         )
 
+    def on_transactions_table_journal_changed(
+        self, event: TransactionsTable.JournalChanged
+    ) -> None:
+        """Reload the transactions table after a journal mutation (edit/delete)."""
+        self._table.reload()
+
     def action_refresh(self) -> None:
         """Reload transactions from the journal."""
         self._table.do_refresh()

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary

- **Fix: refresh account transactions view after edit/delete** (#84) — The `AccountTransactionsScreen` was missing a handler for `TransactionsTable.JournalChanged`, so editing or deleting a transaction from the accounts tab did not refresh the view.
- Bump version to 0.2.3

## Test plan

- [x] Edit a transaction from the accounts tab → view refreshes automatically
- [x] Delete a transaction from the accounts tab → view refreshes automatically
- [x] Edit/delete from transactions tab still works as before