### PR TITLE
feat: add tree/flat view toggle to reports pane

### DIFF
--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -322,6 +322,26 @@ def load_account_balances(
     return result
 
 
+def _parse_tree_account(raw: str) -> tuple[str, int]:
+    """Split a tree-indented hledger account cell into (name, depth).
+
+    hledger's ``--tree`` CSV output prefixes child accounts with two
+    non-breaking spaces (``\\xa0``) per hierarchy level. This helper strips
+    those and returns the cleaned name plus its zero-based depth.
+
+    Args:
+        raw: The raw account cell from an hledger CSV row.
+
+    Returns:
+        A ``(name, depth)`` tuple. For top-level or flat-mode rows ``depth``
+        is ``0``.
+    """
+    rstripped = raw.rstrip()
+    stripped = rstripped.lstrip(" \xa0")
+    depth = (len(rstripped) - len(stripped)) // 2
+    return stripped, depth
+
+
 def load_account_tree_balances(file: str | Path) -> list["AccountNode"]:
     """Load accounts as a tree with hierarchical balances.
 
@@ -349,16 +369,11 @@ def load_account_tree_balances(file: str | Path) -> list["AccountNode"]:
     for row in reader:
         if len(row) < 2 or not row[0]:
             continue
-        raw_name = row[0]
-        balance = row[1]
-        stripped = raw_name.lstrip(" \xa0")
-        depth = len(raw_name) - len(stripped)
-        # hledger uses 2-space indentation per level
-        depth = depth // 2
+        name, depth = _parse_tree_account(row[0])
         flat_nodes.append(AccountNode(
-            name=stripped,
+            name=name,
             full_path="",  # resolved below
-            balance=balance,
+            balance=row[1],
             depth=depth,
         ))
 
@@ -1217,7 +1232,7 @@ def _parse_report_csv(output: str) -> ReportData:
         if not row:
             continue
 
-        account = row[0].strip()
+        account, depth = _parse_tree_account(row[0])
         if not account:
             continue
 
@@ -1234,6 +1249,7 @@ def _parse_report_csv(output: str) -> ReportData:
             amounts=amounts,
             is_section_header=is_section_header,
             is_total=is_total,
+            depth=depth,
         ))
 
     return ReportData(

--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -9,6 +9,7 @@ import shlex
 import subprocess
 from decimal import Decimal
 from pathlib import Path
+from typing import Literal
 
 import re
 
@@ -1249,6 +1250,7 @@ def load_report(
     period_end: str | None = None,
     commodity: str | None = None,
     cache: "HledgerCache | None" = None,
+    mode: Literal["tree", "flat"] = "flat",
 ) -> ReportData:
     """Load a multi-period financial report from hledger.
 
@@ -1263,6 +1265,8 @@ def load_report(
         commodity: Optional commodity code for ``-X`` flag to convert
             multi-commodity amounts into a single commodity.
         cache: Optional cache instance to avoid repeated subprocess calls.
+        mode: ``"flat"`` (default) renders fully qualified leaf accounts;
+            ``"tree"`` renders a hierarchical view with parent subtotals.
 
     Returns:
         A :class:`ReportData` with the parsed report.
@@ -1270,13 +1274,13 @@ def load_report(
     Raises:
         HledgerError: If hledger fails or is not found.
     """
-    cache_key = ("load_report", str(file), report_type, period_begin, period_end, commodity)
+    cache_key = ("load_report", str(file), report_type, period_begin, period_end, commodity, mode)
     if cache is not None:
         cached = cache.get(cache_key, file=file)
         if cached is not None:
             return cached
 
-    args = [report_type, "-M", "-O", "csv", "--no-elide"]
+    args = [report_type, "-M", "-O", "csv", "--no-elide", f"--{mode}"]
     if commodity:
         args.extend(["-X", commodity])
     if period_begin:

--- a/src/hledger_textual/models.py
+++ b/src/hledger_textual/models.py
@@ -251,6 +251,7 @@ class ReportRow:
     amounts: list[str] = field(default_factory=list)
     is_section_header: bool = False
     is_total: bool = False
+    depth: int = 0
 
 
 @dataclass

--- a/src/hledger_textual/widgets/accounts_pane.py
+++ b/src/hledger_textual/widgets/accounts_pane.py
@@ -21,10 +21,10 @@ from hledger_textual.hledger import (
     load_account_tree_balances,
 )
 from hledger_textual.models import AccountNode
+from hledger_textual.widgets.constants import TREE_INDENT
 from hledger_textual.widgets.formatting import fmt_amount_str
 from hledger_textual.widgets.pane_mixin import DataTablePaneMixin
 
-_INDENT = "  "
 _EXPANDED = "\u25bc "
 _COLLAPSED = "\u25b6 "
 _LEAF = "  "
@@ -137,7 +137,7 @@ class AccountsPane(DataTablePaneMixin, Widget):
             node: The AccountNode to render.
             depth: Current indentation depth.
         """
-        indent = _INDENT * depth
+        indent = TREE_INDENT * depth
         if node.children:
             icon = _EXPANDED if node.expanded else _COLLAPSED
         else:
@@ -161,7 +161,7 @@ class AccountsPane(DataTablePaneMixin, Widget):
             rows.extend(self._collect_filtered_rows(root, 0, term))
 
         for full_path, balance, depth, has_children in rows:
-            indent = _INDENT * depth
+            indent = TREE_INDENT * depth
             icon = _EXPANDED if has_children else _LEAF
             label = Text(f"{indent}{icon}{full_path.rsplit(':', 1)[-1]}")
             if has_children:

--- a/src/hledger_textual/widgets/constants.py
+++ b/src/hledger_textual/widgets/constants.py
@@ -1,4 +1,4 @@
-"""Shared constants for input widgets."""
+"""Shared constants used across widgets."""
 
 PASSTHROUGH_KEYS: frozenset[str] = frozenset(
     {
@@ -17,3 +17,6 @@ PASSTHROUGH_KEYS: frozenset[str] = frozenset(
     }
 )
 """Keys that should pass through to the default Input handler."""
+
+TREE_INDENT = "  "
+"""Visual indentation used per hierarchy level when rendering account trees."""

--- a/src/hledger_textual/widgets/reports_pane.py
+++ b/src/hledger_textual/widgets/reports_pane.py
@@ -25,6 +25,7 @@ from hledger_textual.config import (
 from hledger_textual.hledger import HledgerError, load_investment_report, load_report, run_custom_report
 from hledger_textual.models import CustomReport, ReportData, ReportRow
 from hledger_textual.widgets import distribute_column_widths
+from hledger_textual.widgets.constants import TREE_INDENT
 from hledger_textual.widgets.formatting import fmt_amount_str
 from hledger_textual.widgets.pane_mixin import DataTablePaneMixin
 from hledger_textual.widgets.pane_toolbar import PaneToolbar
@@ -467,7 +468,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
                     f"[bold yellow]{row.account}[/bold yellow]", emoji=False
                 )
             else:
-                account_text = Text(row.account)
+                account_text = Text(TREE_INDENT * row.depth + row.account)
 
             cells = [account_text]
             for amt in row.amounts:

--- a/src/hledger_textual/widgets/reports_pane.py
+++ b/src/hledger_textual/widgets/reports_pane.py
@@ -189,6 +189,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
         Binding("r", "refresh", "Refresh", show=True, priority=True),
         Binding("c", "toggle_chart", "Chart", show=False, priority=True),
         Binding("i", "toggle_investments", "Investments", show=False, priority=True),
+        Binding("t", "toggle_tree", "Tree/Flat", show=True, priority=True),
         Binding("x", "export", "Export", show=False, priority=True),
         Binding("n", "new_custom_report", "New report", show=True, priority=True),
         Binding("e", "edit_custom_report", "Edit report", show=False, priority=True),
@@ -213,6 +214,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
         self._report_data: ReportData | None = None
         self._fixed_widths: dict[int, int] = {}
         self._show_investments: bool = False
+        self._tree_mode: bool = False
         self._custom_report_name: str | None = None
 
     def compose(self) -> ComposeResult:
@@ -369,6 +371,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
                 period_end=end,
                 commodity=commodity,
                 cache=self._cache,
+                mode="tree" if self._tree_mode else "flat",
             )
         except HledgerError as exc:
             self.app.call_from_thread(
@@ -513,6 +516,14 @@ class ReportsPane(DataTablePaneMixin, Widget):
         self._show_investments = not self._show_investments
         label = "Investments shown" if self._show_investments else "Investments hidden"
         self.notify(label, timeout=2)
+        self._load_report_data()
+
+    def action_toggle_tree(self) -> None:
+        """Switch between flat and tree view for built-in reports."""
+        if self._custom_report_name is not None:
+            return
+        self._tree_mode = not self._tree_mode
+        self.notify("Tree view" if self._tree_mode else "Flat view", timeout=2)
         self._load_report_data()
 
     def action_refresh(self) -> None:

--- a/tests/test_hledger.py
+++ b/tests/test_hledger.py
@@ -471,6 +471,42 @@ class TestParseReportCsv:
         assert data.rows == []
 
 
+class TestLoadReportTreeDepth:
+    """Tests for tree-mode depth detection via real hledger."""
+
+    def test_tree_depth_reflects_account_hierarchy(self, sample_journal_path: Path):
+        """In tree mode, nested accounts have increasing depth."""
+        data = load_report(sample_journal_path, "is", mode="tree")
+        by_account = {r.account: r for r in data.rows}
+
+        # sample.journal has expenses → food → groceries (depth 0 → 1 → 2)
+        assert by_account["expenses"].depth == 0
+        assert by_account["food"].depth == 1
+        assert by_account["groceries"].depth == 2
+
+    def test_tree_depth_account_name_stripped(self, sample_journal_path: Path):
+        """Tree-mode account names no longer carry leading indentation."""
+        data = load_report(sample_journal_path, "is", mode="tree")
+        accounts = [r.account for r in data.rows]
+        assert "groceries" in accounts
+        assert not any(a.startswith(" ") for a in accounts)
+
+    def test_tree_section_headers_and_totals_have_zero_depth(
+        self, sample_journal_path: Path
+    ):
+        """Section headers and totals stay at depth 0 in tree mode."""
+        data = load_report(sample_journal_path, "is", mode="tree")
+        for row in data.rows:
+            if row.is_section_header or row.is_total:
+                assert row.depth == 0
+
+    def test_flat_mode_all_rows_zero_depth(self, sample_journal_path: Path):
+        """In flat mode every row has depth 0."""
+        data = load_report(sample_journal_path, "is", mode="flat")
+        for row in data.rows:
+            assert row.depth == 0
+
+
 class TestLoadReport:
     """Tests for load_report using monkeypatched run_hledger."""
 

--- a/tests/test_hledger.py
+++ b/tests/test_hledger.py
@@ -547,6 +547,59 @@ class TestLoadReport:
         with pytest.raises(HledgerError):
             load_report(journal, "bs")
 
+    def test_load_report_default_mode_is_flat(self, monkeypatch, tmp_path: Path):
+        """load_report passes --flat to hledger by default."""
+        captured_args: list[str] = []
+
+        def _capture(*args, **kwargs):
+            captured_args.extend(args)
+            return self._SAMPLE_CSV
+
+        monkeypatch.setattr("hledger_textual.hledger.run_hledger", _capture)
+        journal = tmp_path / "test.journal"
+        journal.write_text("; empty\n")
+        load_report(journal, "cf")
+        assert "--flat" in captured_args
+        assert "--tree" not in captured_args
+
+    def test_load_report_tree_mode_passes_tree_flag(self, monkeypatch, tmp_path: Path):
+        """load_report passes --tree when mode='tree'."""
+        captured_args: list[str] = []
+
+        def _capture(*args, **kwargs):
+            captured_args.extend(args)
+            return self._SAMPLE_CSV
+
+        monkeypatch.setattr("hledger_textual.hledger.run_hledger", _capture)
+        journal = tmp_path / "test.journal"
+        journal.write_text("; empty\n")
+        load_report(journal, "cf", mode="tree")
+        assert "--tree" in captured_args
+        assert "--flat" not in captured_args
+
+    def test_load_report_cache_key_distinguishes_modes(self, monkeypatch, tmp_path: Path):
+        """Tree and flat results are cached under distinct keys."""
+        from hledger_textual.cache import HledgerCache
+
+        call_count = 0
+
+        def _capture(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._SAMPLE_CSV
+
+        monkeypatch.setattr("hledger_textual.hledger.run_hledger", _capture)
+        journal = tmp_path / "test.journal"
+        journal.write_text("; empty\n")
+        cache = HledgerCache()
+
+        load_report(journal, "cf", cache=cache, mode="flat")
+        load_report(journal, "cf", cache=cache, mode="flat")
+        assert call_count == 1
+
+        load_report(journal, "cf", cache=cache, mode="tree")
+        assert call_count == 2
+
 
 @pytest.mark.skipif(False, reason="pure function, no hledger needed")
 class TestExpandSearchQuery:

--- a/tests/test_reports_pane.py
+++ b/tests/test_reports_pane.py
@@ -396,6 +396,51 @@ class TestReportsPaneInvestments:
             assert not pane._tree_mode
             assert captured_modes[-1] == "flat"
 
+    async def test_tree_rows_are_rendered_with_indentation(
+        self, reports_journal: Path, monkeypatch
+    ):
+        """Rows with depth > 0 are prefixed with 2 spaces per level in the table."""
+        from textual.coordinate import Coordinate
+
+        data = ReportData(
+            title="IS",
+            period_headers=["Jan"],
+            rows=[
+                ReportRow(account="Revenues", amounts=[""], is_section_header=True),
+                ReportRow(account="income", amounts=["€100.00"], depth=0),
+                ReportRow(account="salary", amounts=["€80.00"], depth=1),
+                ReportRow(account="freelance", amounts=["€20.00"], depth=1),
+                ReportRow(account="Total:", amounts=["€100.00"], is_total=True),
+                ReportRow(account="Expenses", amounts=[""], is_section_header=True),
+                ReportRow(account="expenses", amounts=["€50.00"], depth=0),
+                ReportRow(account="food", amounts=["€30.00"], depth=1),
+                ReportRow(account="groceries", amounts=["€25.00"], depth=2),
+            ],
+        )
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report",
+            lambda *args, **kwargs: data,
+        )
+        app = _ReportsApp(reports_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.5)
+            table = app.query_one("#reports-table", DataTable)
+
+            cells_by_account: dict[str, str] = {}
+            for row_idx in range(table.row_count):
+                cell = table.get_cell_at(Coordinate(row_idx, 0))
+                text = cell.plain if hasattr(cell, "plain") else str(cell)
+                stripped = text.lstrip(" ")
+                if stripped:
+                    cells_by_account[stripped] = text
+
+            assert cells_by_account["income"] == "income"
+            assert cells_by_account["salary"] == "  salary"
+            assert cells_by_account["freelance"] == "  freelance"
+            assert cells_by_account["expenses"] == "expenses"
+            assert cells_by_account["food"] == "  food"
+            assert cells_by_account["groceries"] == "    groceries"
+
     async def test_t_key_noop_when_custom_report_active(
         self, reports_journal: Path, monkeypatch
     ):

--- a/tests/test_reports_pane.py
+++ b/tests/test_reports_pane.py
@@ -365,6 +365,58 @@ class TestReportsPaneInvestments:
             assert "Investments" not in section_names
             assert inv_call_count == 0
 
+    async def test_t_key_toggles_tree_mode(
+        self, reports_journal: Path, monkeypatch
+    ):
+        """Pressing t flips _tree_mode and triggers reload with the new mode."""
+        captured_modes: list[str] = []
+
+        def _mock_load(*args, **kwargs):
+            captured_modes.append(kwargs.get("mode", "flat"))
+            return ReportData(title="IS", period_headers=["Jan"], rows=[])
+
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report", _mock_load
+        )
+        app = _ReportsApp(reports_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.5)
+            pane = app.query_one(ReportsPane)
+            assert not pane._tree_mode
+            assert captured_modes[-1] == "flat"
+
+            pane.focus()
+            await pilot.press("t")
+            await pilot.pause(delay=0.5)
+            assert pane._tree_mode
+            assert captured_modes[-1] == "tree"
+
+            await pilot.press("t")
+            await pilot.pause(delay=0.5)
+            assert not pane._tree_mode
+            assert captured_modes[-1] == "flat"
+
+    async def test_t_key_noop_when_custom_report_active(
+        self, reports_journal: Path, monkeypatch
+    ):
+        """Pressing t does nothing when a custom report is active."""
+        def _mock_load(*args, **kwargs):
+            return ReportData(title="IS", period_headers=["Jan"], rows=[])
+
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report", _mock_load
+        )
+        app = _ReportsApp(reports_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.5)
+            pane = app.query_one(ReportsPane)
+            pane._custom_report_name = "my-report"
+            initial = pane._tree_mode
+            pane.focus()
+            await pilot.press("t")
+            await pilot.pause(delay=0.2)
+            assert pane._tree_mode == initial
+
     async def test_empty_investment_data_no_extra_rows(
         self, reports_journal: Path, monkeypatch
     ):


### PR DESCRIPTION
Press `t` on the reports tab to switch between flat view (default, fully qualified leaf accounts) and tree view (hierarchical with parent subtotals). load_report now takes a `mode` parameter that maps to hledger's --flat/--tree flag and is part of the cache key.