### PR TITLE
feat: sort by amount in reports pane

### DIFF
--- a/src/hledger_textual/app.py
+++ b/src/hledger_textual/app.py
@@ -38,7 +38,7 @@ def _build_footer_commands(sync_enabled: bool) -> dict[str, str]:
         "transactions": f"\\[a] Add  \\[e] Edit  \\[d] Del  \\[c] Clone  \\[m] Move  \\[◄/►] Month  \\[/] Search  \\[f] Filters  \\[^s] Save filter  {global_part}",
         "accounts": f"\\[↵] Drill  \\[/] Search  \\[r] Reload  {global_part}",
         "budget": f"\\[a] Add  \\[e] Edit  \\[d] Del  \\[◄/►] Month  \\[/] Search  \\[o] Overview  {global_part}",
-        "reports": f"\\[n] New  \\[c] Chart  \\[i] Inv  \\[r] Reload  {global_part}",
+        "reports": f"\\[n] New  \\[S] Sort  \\[c] Chart  \\[i] Inv  \\[r] Reload  {global_part}",
         "reports-custom": f"\\[esc] Back  \\[n] New  \\[e] Edit  \\[d] Del  \\[r] Reload  {global_part}",
         "recurring": f"\\[a] Add  \\[e] Edit  \\[d] Del  \\[g] Generate  \\[r] Reload  {global_part}",
     }

--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -1265,6 +1265,7 @@ def load_report(
     period_begin: str | None = None,
     period_end: str | None = None,
     commodity: str | None = None,
+    sort_amount: bool = False,
     cache: "HledgerCache | None" = None,
     mode: Literal["tree", "flat"] = "flat",
 ) -> ReportData:
@@ -1290,13 +1291,15 @@ def load_report(
     Raises:
         HledgerError: If hledger fails or is not found.
     """
-    cache_key = ("load_report", str(file), report_type, period_begin, period_end, commodity, mode)
+    cache_key = ("load_report", str(file), report_type, period_begin, period_end, commodity, sort_amount, mode)
     if cache is not None:
         cached = cache.get(cache_key, file=file)
         if cached is not None:
             return cached
 
     args = [report_type, "-M", "-O", "csv", "--no-elide", f"--{mode}"]
+    if sort_amount:
+        args.append("--sort-amount")
     if commodity:
         args.extend(["-X", commodity])
     if period_begin:

--- a/src/hledger_textual/screens/help.py
+++ b/src/hledger_textual/screens/help.py
@@ -90,6 +90,7 @@ def _build_help_text() -> str:
             [
                 ("c", "Toggle chart"),
                 ("i", "Investment view"),
+                ("S", "Sort by amount"),
                 ("r", "Reload"),
             ],
         ),

--- a/src/hledger_textual/widgets/reports_pane.py
+++ b/src/hledger_textual/widgets/reports_pane.py
@@ -191,6 +191,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
         Binding("c", "toggle_chart", "Chart", show=False, priority=True),
         Binding("i", "toggle_investments", "Investments", show=False, priority=True),
         Binding("t", "toggle_tree", "Tree/Flat", show=True, priority=True),
+        Binding("S", "toggle_sort_amount", "Sort amount", show=True, priority=True),
         Binding("x", "export", "Export", show=False, priority=True),
         Binding("n", "new_custom_report", "New report", show=True, priority=True),
         Binding("e", "edit_custom_report", "Edit report", show=False, priority=True),
@@ -216,6 +217,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
         self._fixed_widths: dict[int, int] = {}
         self._show_investments: bool = False
         self._tree_mode: bool = False
+        self._sort_amount: bool = False
         self._custom_report_name: str | None = None
 
     def compose(self) -> ComposeResult:
@@ -371,6 +373,7 @@ class ReportsPane(DataTablePaneMixin, Widget):
                 period_begin=begin,
                 period_end=end,
                 commodity=commodity,
+                sort_amount=self._sort_amount,
                 cache=self._cache,
                 mode="tree" if self._tree_mode else "flat",
             )
@@ -525,6 +528,15 @@ class ReportsPane(DataTablePaneMixin, Widget):
             return
         self._tree_mode = not self._tree_mode
         self.notify("Tree view" if self._tree_mode else "Flat view", timeout=2)
+        self._load_report_data()
+
+    def action_toggle_sort_amount(self) -> None:
+        """Toggle sorting report rows by amount (hledger --sort-amount)."""
+        if self._custom_report_name is not None:
+            return
+        self._sort_amount = not self._sort_amount
+        label = "Sorted by amount" if self._sort_amount else "Sorted by account"
+        self.notify(label, timeout=2)
         self._load_report_data()
 
     def action_refresh(self) -> None:

--- a/tests/test_hledger.py
+++ b/tests/test_hledger.py
@@ -636,6 +636,48 @@ class TestLoadReport:
         load_report(journal, "cf", cache=cache, mode="tree")
         assert call_count == 2
 
+    def test_load_report_sort_amount_flag(self, monkeypatch, tmp_path: Path):
+        """load_report passes --sort-amount only when sort_amount=True."""
+        captured_args: list[str] = []
+
+        def _capture(*args, **kwargs):
+            captured_args.extend(args)
+            return self._SAMPLE_CSV
+
+        monkeypatch.setattr("hledger_textual.hledger.run_hledger", _capture)
+        journal = tmp_path / "test.journal"
+        journal.write_text("; empty\n")
+
+        load_report(journal, "cf")
+        assert "--sort-amount" not in captured_args
+
+        captured_args.clear()
+        load_report(journal, "cf", sort_amount=True)
+        assert "--sort-amount" in captured_args
+
+    def test_load_report_cache_key_distinguishes_sort_amount(self, monkeypatch, tmp_path: Path):
+        """Sorted and unsorted results are cached under distinct keys."""
+        from hledger_textual.cache import HledgerCache
+
+        call_count = 0
+
+        def _capture(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return self._SAMPLE_CSV
+
+        monkeypatch.setattr("hledger_textual.hledger.run_hledger", _capture)
+        journal = tmp_path / "test.journal"
+        journal.write_text("; empty\n")
+        cache = HledgerCache()
+
+        load_report(journal, "cf", cache=cache, sort_amount=False)
+        load_report(journal, "cf", cache=cache, sort_amount=False)
+        assert call_count == 1
+
+        load_report(journal, "cf", cache=cache, sort_amount=True)
+        assert call_count == 2
+
 
 @pytest.mark.skipif(False, reason="pure function, no hledger needed")
 class TestExpandSearchQuery:


### PR DESCRIPTION
This adds functionality to sort by amount instead of by account in the reports pane. It uses the native hledger `--sort-amount` flag to do the ordering. It also adds basic tests for this functionality.

I chose `SHIFT+S` as keybind, since that is globally available and is intuitive for **S**orting. Let me know if you agree with that.

Also let me know if it's OK like this or if you need me to make any changes.