### PR TITLE
fix: handle European number format in amount parsing (issue #105)

### DIFF
--- a/src/hledger_textual/amountutil.py
+++ b/src/hledger_textual/amountutil.py
@@ -6,8 +6,55 @@ import re
 from decimal import Decimal, InvalidOperation
 
 
+def _normalize_number_string(s: str) -> str:
+    """Normalize a raw number string to standard decimal notation.
+
+    Supports both US format (1,000.00 — dot as decimal separator) and European
+    format (1.000,00 — comma as decimal separator).  The decimal separator is
+    detected by the position of the *last* separator character in the string:
+    whichever of ``,`` or ``.`` appears furthest to the right is treated as the
+    decimal separator.  When only a comma is present a two-digit heuristic is
+    applied: if exactly one or two digits follow the last comma the comma is
+    treated as a decimal separator (e.g. ``100,00`` → ``100.00``); otherwise it
+    is treated as a thousands separator (e.g. ``1,000`` → ``1000``).
+
+    Args:
+        s: A raw number string, optionally prefixed with a minus sign.
+
+    Returns:
+        The number string in standard ``Decimal``-parseable notation.
+    """
+    negative = s.startswith("-")
+    core = s[1:] if negative else s
+
+    has_dot = "." in core
+    has_comma = "," in core
+
+    if has_dot and has_comma:
+        if core.rfind(",") > core.rfind("."):
+            # European: 1.000,00 — comma is the decimal separator
+            normalized = core.replace(".", "").replace(",", ".")
+        else:
+            # US: 1,000.00 — dot is the decimal separator
+            normalized = core.replace(",", "")
+    elif has_comma:
+        after_last_comma = core[core.rfind(",") + 1:]
+        if len(after_last_comma) <= 2 and after_last_comma.isdigit():
+            # Decimal comma: 100,00 → 100.00
+            normalized = core.replace(",", ".")
+        else:
+            # Thousands comma: 1,000 → 1000
+            normalized = core.replace(",", "")
+    else:
+        normalized = core
+
+    return f"-{normalized}" if negative else normalized
+
+
 def parse_amount_string(s: str) -> tuple[Decimal, str]:
     """Parse an amount string like '€800.00' or '150.00 EUR' into (quantity, commodity).
+
+    Handles both US (1,000.00) and European (1.000,00) number formats.
 
     Args:
         s: The amount string to parse.
@@ -22,21 +69,21 @@ def parse_amount_string(s: str) -> tuple[Decimal, str]:
     if not s:
         raise ValueError("Empty amount string")
 
-    # Try left-side commodity: €800.00, $500, $1,320.28
+    # Try left-side commodity: €800.00, $500, $1,320.28, €1.000,00
     match = re.match(r"^([^\d\s.,-]+)\s*(-?[\d,.]+)$", s)
     if match:
         commodity = match.group(1)
         try:
-            quantity = Decimal(match.group(2).replace(",", ""))
+            quantity = Decimal(_normalize_number_string(match.group(2)))
         except InvalidOperation:
             raise ValueError(f"Invalid amount: {s}")
         return quantity, commodity
 
-    # Try right-side commodity: 800.00 EUR, 1,320.28 EUR
+    # Try right-side commodity: 800.00 EUR, 1,320.28 EUR, 1.000,00 EUR
     match = re.match(r"^(-?[\d,.]+)\s*([^\d\s.,-]+)$", s)
     if match:
         try:
-            quantity = Decimal(match.group(1).replace(",", ""))
+            quantity = Decimal(_normalize_number_string(match.group(1)))
         except InvalidOperation:
             raise ValueError(f"Invalid amount: {s}")
         commodity = match.group(2)

--- a/src/hledger_textual/hledger.py
+++ b/src/hledger_textual/hledger.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 import re
 
+from hledger_textual.amountutil import _normalize_number_string
 from hledger_textual.models import (
     Amount,
     AmountStyle,
@@ -601,29 +602,27 @@ def _parse_budget_amount(s: str) -> tuple[Decimal, str]:
     if not s or s == "0":
         return Decimal("0"), ""
 
-    # Left-side commodity: €500.00
+    # Left-side commodity: €500.00, €1.000,00
     match = re.match(r"^([^\d\s.-]+)\s*(-?[\d,.]+)$", s)
     if match:
         commodity = match.group(1)
-        num_str = match.group(2).replace(",", "")
         try:
-            return Decimal(num_str), commodity
+            return Decimal(_normalize_number_string(match.group(2))), commodity
         except Exception:
             return Decimal("0"), commodity
 
-    # Right-side commodity: 500.00 EUR
+    # Right-side commodity: 500.00 EUR, 1.000,00 EUR
     match = re.match(r"^(-?[\d,.]+)\s*([^\d\s.-]+)$", s)
     if match:
-        num_str = match.group(1).replace(",", "")
         commodity = match.group(2)
         try:
-            return Decimal(num_str), commodity
+            return Decimal(_normalize_number_string(match.group(1))), commodity
         except Exception:
             return Decimal("0"), commodity
 
     # Plain number
     try:
-        return Decimal(s.replace(",", "")), ""
+        return Decimal(_normalize_number_string(s)), ""
     except Exception:
         return Decimal("0"), ""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,18 @@ def has_hledger() -> bool:
 
 
 @pytest.fixture
+def european_journal_path() -> Path:
+    """Path to the European-format journal fixture (€1.000,00)."""
+    return FIXTURES_DIR / "european.journal"
+
+
+@pytest.fixture
+def us_journal_path() -> Path:
+    """Path to the US-format journal fixture ($1,000.00)."""
+    return FIXTURES_DIR / "us.journal"
+
+
+@pytest.fixture
 def sample_budget_journal_path() -> Path:
     """Path to the sample budget journal fixture."""
     return FIXTURES_DIR / "sample_budget.journal"

--- a/tests/fixtures/european.journal
+++ b/tests/fixtures/european.journal
@@ -1,0 +1,16 @@
+; European format journal for testing.
+; Uses dot as thousands separator and comma as decimal separator (€1.000,00).
+
+commodity €1.000,00
+
+2026-01-15 * Salary
+    assets:bank:checking         €3.000,00
+    income:salary
+
+2026-01-20 * Groceries
+    expenses:food                  €150,00
+    assets:bank:checking
+
+2026-01-25 * Transport
+    expenses:transport              €50,00
+    assets:bank:checking

--- a/tests/fixtures/us.journal
+++ b/tests/fixtures/us.journal
@@ -1,0 +1,16 @@
+; US format journal for testing.
+; Uses comma as thousands separator and dot as decimal separator ($1,000.00).
+
+commodity $1,000.00
+
+2026-01-15 * Salary
+    assets:bank:checking        $3,000.00
+    income:salary
+
+2026-01-20 * Groceries
+    expenses:food                 $150.00
+    assets:bank:checking
+
+2026-01-25 * Transport
+    expenses:transport             $50.00
+    assets:bank:checking

--- a/tests/test_amountutil.py
+++ b/tests/test_amountutil.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 
 import pytest
 
-from hledger_textual.amountutil import parse_amount_string
+from hledger_textual.amountutil import _normalize_number_string, parse_amount_string
 
 
 class TestParseAmountString:
@@ -75,3 +75,81 @@ class TestParseAmountString:
         """Unparseable string raises ValueError."""
         with pytest.raises(ValueError):
             parse_amount_string("notanamount")
+
+    # --- European format (comma as decimal, dot as thousands) ---
+
+    def test_european_left_commodity_no_thousands(self):
+        """Parse European amount without thousands separator: €100,00 → 100.00."""
+        qty, commodity = parse_amount_string("€100,00")
+        assert qty == Decimal("100.00")
+        assert commodity == "€"
+
+    def test_european_left_commodity_with_thousands(self):
+        """Parse European amount with thousands separator: €1.000,00 → 1000.00."""
+        qty, commodity = parse_amount_string("€1.000,00")
+        assert qty == Decimal("1000.00")
+        assert commodity == "€"
+
+    def test_european_left_commodity_large(self):
+        """Parse large European amount with multiple thousands separators."""
+        qty, commodity = parse_amount_string("€1.234.567,89")
+        assert qty == Decimal("1234567.89")
+        assert commodity == "€"
+
+    def test_european_right_commodity(self):
+        """Parse European amount with right-side commodity: 1.000,00 EUR → 1000.00."""
+        qty, commodity = parse_amount_string("1.000,00 EUR")
+        assert qty == Decimal("1000.00")
+        assert commodity == "EUR"
+
+    def test_european_negative(self):
+        """Parse negative European amount: €-150,50 → -150.50."""
+        qty, commodity = parse_amount_string("€-150,50")
+        assert qty == Decimal("-150.50")
+        assert commodity == "€"
+
+    def test_european_salary(self):
+        """Parse European salary amount matching the fixture: €3.000,00 → 3000.00."""
+        qty, commodity = parse_amount_string("€3.000,00")
+        assert qty == Decimal("3000.00")
+        assert commodity == "€"
+
+
+class TestNormalizeNumberString:
+    """Tests for _normalize_number_string."""
+
+    def test_us_with_thousands(self):
+        """US format with thousands separator: 1,000.00 → 1000.00."""
+        assert _normalize_number_string("1,000.00") == "1000.00"
+
+    def test_us_plain(self):
+        """Plain decimal: 150.00 → 150.00."""
+        assert _normalize_number_string("150.00") == "150.00"
+
+    def test_european_with_thousands(self):
+        """European format: 1.000,00 → 1000.00."""
+        assert _normalize_number_string("1.000,00") == "1000.00"
+
+    def test_european_no_thousands(self):
+        """European decimal-only: 100,00 → 100.00."""
+        assert _normalize_number_string("100,00") == "100.00"
+
+    def test_european_large(self):
+        """European with multiple thousands separators: 1.234.567,89 → 1234567.89."""
+        assert _normalize_number_string("1.234.567,89") == "1234567.89"
+
+    def test_negative_european(self):
+        """Negative European: -1.000,00 → -1000.00."""
+        assert _normalize_number_string("-1.000,00") == "-1000.00"
+
+    def test_negative_us(self):
+        """Negative US: -1,000.00 → -1000.00."""
+        assert _normalize_number_string("-1,000.00") == "-1000.00"
+
+    def test_thousands_comma_only(self):
+        """Comma-only with 3 trailing digits: thousands separator."""
+        assert _normalize_number_string("1,000") == "1000"
+
+    def test_plain_integer(self):
+        """Plain integer with no separators passes through unchanged."""
+        assert _normalize_number_string("3000") == "3000"

--- a/tests/test_hledger.py
+++ b/tests/test_hledger.py
@@ -191,6 +191,43 @@ class TestParseBudgetAmount:
         assert qty == Decimal("0")
         assert commodity == ""
 
+    # --- European format (comma as decimal, dot as thousands) ---
+
+    def test_european_no_thousands(self):
+        """European decimal comma without thousands separator: €100,00 → 100.00."""
+        from decimal import Decimal
+        qty, commodity = _parse_budget_amount("€100,00")
+        assert qty == Decimal("100.00")
+        assert commodity == "€"
+
+    def test_european_with_thousands(self):
+        """European with dot thousands separator: €1.000,00 → 1000.00."""
+        from decimal import Decimal
+        qty, commodity = _parse_budget_amount("€1.000,00")
+        assert qty == Decimal("1000.00")
+        assert commodity == "€"
+
+    def test_european_salary(self):
+        """European salary amount matching the fixture: €3.000,00 → 3000.00."""
+        from decimal import Decimal
+        qty, commodity = _parse_budget_amount("€3.000,00")
+        assert qty == Decimal("3000.00")
+        assert commodity == "€"
+
+    def test_european_right_side(self):
+        """European format with right-side commodity code."""
+        from decimal import Decimal
+        qty, commodity = _parse_budget_amount("1.000,00 EUR")
+        assert qty == Decimal("1000.00")
+        assert commodity == "EUR"
+
+    def test_european_plain_number_decimal_comma(self):
+        """Plain European decimal number (no commodity): 100,00 → 100.00."""
+        from decimal import Decimal
+        qty, commodity = _parse_budget_amount("100,00")
+        assert qty == Decimal("100.00")
+        assert commodity == ""
+
 
 class TestLoadJournalStats:
     """Tests for load_journal_stats."""
@@ -290,6 +327,50 @@ class TestLoadPeriodSummary:
         assert summary.expenses == Decimal("100.00")
         assert summary.investments == Decimal("600.00")
         assert summary.net == Decimal("2300.00")
+
+
+class TestLoadPeriodSummaryEuropeanFormat:
+    """Integration tests for load_period_summary with European-format journals.
+
+    These tests guard against the regression reported in issue #105 where amounts
+    like €100,00 (European decimal comma) were parsed as 10000 instead of 100.00,
+    producing 100x inflated totals in the Summary section.
+    """
+
+    def test_european_income(self, european_journal_path: Path):
+        """Income parsed from European format journal should be 3000, not 300000."""
+        summary = load_period_summary(european_journal_path, "2026-01")
+        assert summary.income == Decimal("3000.00")
+
+    def test_european_expenses(self, european_journal_path: Path):
+        """Expenses from European format journal: food €150,00 + transport €50,00 = 200."""
+        summary = load_period_summary(european_journal_path, "2026-01")
+        assert summary.expenses == Decimal("200.00")
+
+    def test_european_net(self, european_journal_path: Path):
+        """Net from European format journal: 3000 - 200 = 2800."""
+        summary = load_period_summary(european_journal_path, "2026-01")
+        assert summary.net == Decimal("2800.00")
+
+    def test_european_commodity(self, european_journal_path: Path):
+        """Commodity detected from European format journal should be €."""
+        summary = load_period_summary(european_journal_path, "2026-01")
+        assert summary.commodity == "€"
+
+    def test_us_income(self, us_journal_path: Path):
+        """Income parsed from US format journal should be 3000."""
+        summary = load_period_summary(us_journal_path, "2026-01")
+        assert summary.income == Decimal("3000.00")
+
+    def test_us_expenses(self, us_journal_path: Path):
+        """Expenses from US format journal: food $150.00 + transport $50.00 = 200."""
+        summary = load_period_summary(us_journal_path, "2026-01")
+        assert summary.expenses == Decimal("200.00")
+
+    def test_us_commodity(self, us_journal_path: Path):
+        """Commodity detected from US format journal should be $."""
+        summary = load_period_summary(us_journal_path, "2026-01")
+        assert summary.commodity == "$"
 
 
 class TestLoadExpenseBreakdown:


### PR DESCRIPTION
## Summary

- Amounts like `€100,00` (comma as decimal separator) were parsed as `10000` instead of `100.00`, producing 100x inflated totals in the Summary section
- Adds `_normalize_number_string()` to `amountutil.py` that detects the decimal separator by the position of the last separator character, supporting both US (`1,000.00`) and European (`1.000,00`) formats
- Updates `_parse_budget_amount()` in `hledger.py` to use the same logic

## Test plan

- [x] New unit tests for `_normalize_number_string` (9 cases)
- [x] New European format tests for `parse_amount_string` (6 cases)
- [x] New European format tests for `_parse_budget_amount` (5 cases)
- [x] Integration tests for `load_period_summary` with real journal fixtures in EU and US format (7 cases)
- [x] Full test suite: 996 passed

Closes #105