### PR TITLE
chore: bump version to 0.2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.2.11"
+version = "0.2.12"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.2.10"
+version = "0.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary
- Bump version from 0.2.11 to 0.2.12 in preparation for release

## Release checklist
- [x] Merge this PR
- [x] Create tag `v0.2.12` and GitHub release