### PR TITLE
fix: preserve European number format when modifying transaction status

### DIFF
--- a/src/hledger_textual/models.py
+++ b/src/hledger_textual/models.py
@@ -48,6 +48,31 @@ class AmountStyle:
     precision: int = 2
 
 
+def _format_integer_with_groups(integer_part: str, separator: str, sizes: list[int]) -> str:
+    """Apply digit grouping to an integer string.
+
+    Args:
+        integer_part: The integer digits as a string (no sign, no decimal point).
+        separator: The character to insert between groups.
+        sizes: Group sizes from right to left; the last size repeats indefinitely.
+
+    Returns:
+        The integer string with group separators inserted.
+    """
+    groups: list[str] = []
+    pos = len(integer_part)
+    group_idx = 0
+
+    while pos > 0:
+        size = sizes[min(group_idx, len(sizes) - 1)]
+        start = max(pos - size, 0)
+        groups.append(integer_part[start:pos])
+        pos = start
+        group_idx += 1
+
+    return separator.join(reversed(groups))
+
+
 @dataclass
 class Amount:
     """A monetary amount with commodity and style.
@@ -66,6 +91,22 @@ class Amount:
         """Format the amount as a string for display."""
         qty_str = f"{abs(self.quantity):.{self.style.precision}f}"
         sign = "-" if self.quantity < 0 else ""
+
+        # Apply locale-aware number formatting (digit grouping and decimal mark).
+        if "." in qty_str:
+            int_part, dec_part = qty_str.split(".", 1)
+        else:
+            int_part, dec_part = qty_str, ""
+
+        if self.style.digit_group_separator and self.style.digit_group_sizes:
+            int_part = _format_integer_with_groups(
+                int_part, self.style.digit_group_separator, self.style.digit_group_sizes
+            )
+
+        if dec_part:
+            qty_str = int_part + self.style.decimal_mark + dec_part
+        else:
+            qty_str = int_part
 
         if self.style.commodity_side == "L":
             space = " " if self.style.commodity_spaced else ""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -82,6 +82,71 @@ class TestAmount:
         amt = Amount(commodity="STCK", quantity=Decimal("-10.00"), style=style, cost=cost)
         assert amt.format() == "-10.00 STCK @@ €200.00"
 
+    def test_format_european_thousands(self):
+        """European format: dot as thousands separator, comma as decimal mark."""
+        style = AmountStyle(
+            commodity_side="L",
+            commodity_spaced=True,
+            decimal_mark=",",
+            digit_group_separator=".",
+            digit_group_sizes=[3],
+            precision=2,
+        )
+        amt = Amount(commodity="€", quantity=Decimal("1000.00"), style=style)
+        assert amt.format() == "€ 1.000,00"
+
+    def test_format_european_large_number(self):
+        """European format applies grouping to numbers with multiple groups."""
+        style = AmountStyle(
+            commodity_side="L",
+            commodity_spaced=True,
+            decimal_mark=",",
+            digit_group_separator=".",
+            digit_group_sizes=[3],
+            precision=2,
+        )
+        amt = Amount(commodity="€", quantity=Decimal("1000000.00"), style=style)
+        assert amt.format() == "€ 1.000.000,00"
+
+    def test_format_european_negative(self):
+        """European format is preserved for negative amounts."""
+        style = AmountStyle(
+            commodity_side="L",
+            commodity_spaced=True,
+            decimal_mark=",",
+            digit_group_separator=".",
+            digit_group_sizes=[3],
+            precision=2,
+        )
+        amt = Amount(commodity="€", quantity=Decimal("-1000.00"), style=style)
+        assert amt.format() == "-€ 1.000,00"
+
+    def test_format_us_thousands(self):
+        """US format: comma as thousands separator, dot as decimal mark."""
+        style = AmountStyle(
+            commodity_side="L",
+            commodity_spaced=False,
+            decimal_mark=".",
+            digit_group_separator=",",
+            digit_group_sizes=[3],
+            precision=2,
+        )
+        amt = Amount(commodity="$", quantity=Decimal("1000.00"), style=style)
+        assert amt.format() == "$1,000.00"
+
+    def test_format_zero_precision_with_grouping(self):
+        """Digit grouping is applied even when precision is zero."""
+        style = AmountStyle(
+            commodity_side="L",
+            commodity_spaced=True,
+            decimal_mark=",",
+            digit_group_separator=".",
+            digit_group_sizes=[3],
+            precision=0,
+        )
+        amt = Amount(commodity="€", quantity=Decimal("1000"), style=style)
+        assert amt.format() == "€ 1.000"
+
 
 class TestTransaction:
     """Tests for Transaction properties."""


### PR DESCRIPTION
## Summary

- `Amount.format()` was ignoring `decimal_mark`, `digit_group_separator`, and `digit_group_sizes` from `AmountStyle`, always producing Python's default format (`.` as decimal mark, no thousands separator)
- Amounts like `€ 1.000,00` were rewritten as `€1000.00` on any transaction modification (status toggle, date move, etc.)
- Adds `_format_integer_with_groups()` helper and updates `Amount.format()` to apply locale-aware formatting

Fixes #108

## Test plan

- [x] New unit tests in `TestAmount` covering European format, US format, large numbers, negative amounts, zero precision with grouping
- [x] All 1001 existing tests pass