### PR TITLE
fix: preserve amount style on non-amount transaction edits (#111)

### DIFF
--- a/src/hledger_textual/screens/transaction_form.py
+++ b/src/hledger_textual/screens/transaction_form.py
@@ -402,6 +402,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                     account=posting.account,
                     amount=amount_str,
                     commodity=commodity,
+                    initial_amounts=posting.amounts if posting.amounts else None,
                 )
         else:
             default_commodity = load_default_commodity()
@@ -414,6 +415,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         account: str = "",
         amount: str = "",
         commodity: str = "",
+        initial_amounts: list[Amount] | None = None,
     ) -> None:
         """Add a new posting row to the form."""
         container = self.query_one("#postings-container", Vertical)
@@ -428,6 +430,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
             commodity=commodity,
             row_index=self.posting_count,
             account_suggestions=self.accounts,
+            initial_amounts=initial_amounts,
         )
         container.mount(row)
         self.posting_count += 1
@@ -570,6 +573,46 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
             return False
 
     @staticmethod
+    def _reuse_initial_amounts(row: PostingRow) -> list[Amount] | None:
+        """Return the original amounts if *row*'s input is semantically unchanged.
+
+        Preserves the original :class:`AmountStyle` (decimal mark, digit
+        grouping, commodity side) when editing a transaction without modifying
+        the amount field.  This avoids round-tripping through
+        :func:`parse_amount_str`, which would otherwise reset the style to a
+        US-formatted default and — in journals declaring European formatting
+        via a ``commodity`` directive — cause hledger to re-interpret the
+        rewritten amount, scaling it by 100× (issue #111).
+
+        The comparison is tolerant of the :class:`AmountInput` blur
+        auto-format, which normalises simple decimals to 2 decimal places
+        (e.g. ``"10"`` → ``"10.00"``) without changing the semantic value.
+
+        Args:
+            row: The posting row whose current input should be compared
+                against the values it was initialised with.
+
+        Returns:
+            The original amounts list when the input is unchanged, otherwise
+            ``None`` to signal that the caller should re-parse the input.
+        """
+        if row.initial_amounts is None:
+            return None
+
+        if row.amount == row.initial_amount.strip():
+            return row.initial_amounts
+
+        # Tolerate blur auto-format for plain single-amount postings.
+        if len(row.initial_amounts) == 1 and row.initial_amounts[0].cost is None:
+            try:
+                if Decimal(row.amount) == row.initial_amounts[0].quantity:
+                    return row.initial_amounts
+            except InvalidOperation:
+                pass
+
+        return None
+
+    @staticmethod
     def _omit_balancing_amount(postings: list[Posting]) -> list[Posting]:
         """Clear the last posting's amounts when hledger can infer the balance.
 
@@ -631,17 +674,29 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
 
             amounts: list[Amount] = []
             if row.amount:
-                default_commodity = row.commodity or load_default_commodity()
-                amount = parse_amount_str(row.amount, default_commodity)
-                if amount is None:
-                    self.notify(
-                        f"Invalid amount: \"{row.amount}\". "
-                        "Use: 50.00 | €50.00 | -5 STCK @@ €200.00 | -5 STCK @ €40.00",
-                        severity="error",
-                        timeout=6,
-                    )
-                    return
-                amounts.append(amount)
+                # When the amount input is unchanged from the value the form
+                # was initialised with, reuse the original Amount objects so
+                # their AmountStyle (decimal mark, digit grouping, commodity
+                # side) is preserved.  Re-parsing the displayed string would
+                # fall back to a default US-style AmountStyle, which — on a
+                # journal that declares European formatting via a commodity
+                # directive — causes hledger to re-interpret the written
+                # amount and scale it by 100× (issue #111).
+                reused = self._reuse_initial_amounts(row)
+                if reused is not None:
+                    amounts.extend(reused)
+                else:
+                    default_commodity = row.commodity or load_default_commodity()
+                    amount = parse_amount_str(row.amount, default_commodity)
+                    if amount is None:
+                        self.notify(
+                            f"Invalid amount: \"{row.amount}\". "
+                            "Use: 50.00 | €50.00 | -5 STCK @@ €200.00 | -5 STCK @ €40.00",
+                            severity="error",
+                            timeout=6,
+                        )
+                        return
+                    amounts.append(amount)
 
             postings.append(Posting(account=account, amounts=amounts))
 

--- a/src/hledger_textual/widgets/posting_row.py
+++ b/src/hledger_textual/widgets/posting_row.py
@@ -8,6 +8,7 @@ from textual.suggester import SuggestFromList
 from textual.widget import Widget
 from textual.widgets import Input, Label
 
+from hledger_textual.models import Amount
 from hledger_textual.widgets.amount_input import AmountInput
 from hledger_textual.widgets.autocomplete_input import AutocompleteInput
 
@@ -28,6 +29,7 @@ class PostingRow(Widget):
         commodity: str = "",
         row_index: int = 0,
         account_suggestions: list[str] | None = None,
+        initial_amounts: list[Amount] | None = None,
     ) -> None:
         """Initialize the posting row.
 
@@ -38,6 +40,12 @@ class PostingRow(Widget):
             commodity: Default commodity shown as a label (e.g. ``€``).
             row_index: Index of this row.
             account_suggestions: List of account names for autocomplete.
+            initial_amounts: The original :class:`Amount` objects from which
+                *amount* was derived, when editing an existing transaction.
+                When the user does not modify *amount*, the form reuses these
+                objects verbatim at save time so that locale-specific styles
+                (European digit grouping, decimal mark, etc.) are preserved
+                rather than lost to the default US parser.
         """
         super().__init__()
         self.initial_label = label
@@ -46,6 +54,7 @@ class PostingRow(Widget):
         self.initial_commodity = commodity
         self.row_index = row_index
         self.account_suggestions = account_suggestions or []
+        self.initial_amounts = initial_amounts
 
     def compose(self) -> ComposeResult:
         """Create the posting row layout."""

--- a/tests/test_transaction_form.py
+++ b/tests/test_transaction_form.py
@@ -414,6 +414,69 @@ class TestBalanceValidation:
             assert not isinstance(app.screen, TransactionFormScreen)
 
 
+class TestEuropeanStylePreservation:
+    """Regression tests for issue #111.
+
+    Editing a European-formatted transaction through the form — even when only
+    the status (or another non-amount field) is touched — must not scale the
+    amount by 100×.  The bug was that the form re-parsed the amount string
+    through ``parse_amount_str``, which produced a default US-style
+    ``AmountStyle`` and caused hledger to re-interpret the rewritten amount
+    against the journal's ``commodity € 1.000,00`` directive.
+    """
+
+    @pytest.fixture
+    def european_journal(self, tmp_path: Path) -> Path:
+        content = (
+            "commodity € 1.000,00\n"
+            "\n"
+            f"{_D3.isoformat()} ! café\n"
+            "    expenses:food          € 10,00\n"
+            "    assets:bank:checking  -€ 10,00\n"
+        )
+        dest = tmp_path / "european.journal"
+        dest.write_text(content)
+        return dest
+
+    @pytest.fixture
+    def european_app(self, european_journal: Path) -> HledgerTuiApp:
+        return HledgerTuiApp(journal_file=european_journal)
+
+    async def test_status_edit_preserves_european_amount(
+        self, european_app: HledgerTuiApp, european_journal: Path
+    ):
+        from textual.widgets import Select
+
+        from hledger_textual.hledger import load_transactions
+
+        async with european_app.run_test(size=(100, 60)) as pilot:
+            await pilot.pause()
+            await pilot.press("2")
+            await pilot.pause()
+            await pilot.press("e")
+            await pilot.pause()
+            form = european_app.screen
+            assert isinstance(form, TransactionFormScreen)
+
+            # Change only the status — leave the amount field untouched.
+            form.query_one("#select-status", Select).value = TransactionStatus.CLEARED
+            form._save()
+            await pilot.pause(delay=1.5)
+            assert not isinstance(european_app.screen, TransactionFormScreen)
+
+        reloaded = load_transactions(european_journal)
+        cafe = next(t for t in reloaded if t.description == "café")
+        assert cafe.status == TransactionStatus.CLEARED
+        # The bug scaled the amount from 10 to 1000 (100×).
+        assert cafe.postings[0].amounts[0].quantity == Decimal("10")
+        assert cafe.postings[1].amounts[0].quantity == Decimal("-10")
+        # The rewritten file must retain European formatting, not fall back
+        # to the US-style "€10.00" which hledger would misread as 1000.
+        file_text = european_journal.read_text()
+        assert "€ 10,00" in file_text
+        assert "€10.00" not in file_text
+
+
 class TestDateValidation:
     """Tests for the _validate_date method directly."""
 


### PR DESCRIPTION
## Summary

- Editing a European-formatted transaction via the form — even only to toggle the status — caused the amount to be scaled by 100× on every save.
- Root cause: `TransactionFormScreen._save` always re-parsed the displayed amount string through `parse_amount_str`, which produced a default US-style `AmountStyle`. When the journal declared European formatting via a `commodity € 1.000,00` directive, hledger re-read the rewritten `€1000.00` treating `.` as a thousands separator and scaled the value accordingly.
- Fix: `PostingRow` now carries the original `list[Amount]` it was initialised with. `_save` reuses those objects verbatim when the amount input is semantically unchanged (string match, with a `Decimal` fallback to tolerate the `AmountInput` 2dp blur auto-format), so `AmountStyle` — and therefore the on-disk format — is preserved.
- Amounts the user actually edits still flow through `parse_amount_str`; behaviour for new transactions, clones, and explicit amount changes is unchanged.

This complements #109, which fixed the keyboard-shortcut status toggle path. The edit-form path was still broken because it reconstructed `Amount` objects from scratch.

Fixes #111

## Test plan

- [x] New regression test `TestEuropeanStylePreservation::test_status_edit_preserves_european_amount` — builds a journal with `commodity € 1.000,00`, opens the edit form on a `€ 10,00` transaction, changes only the status, saves, reloads via hledger, and asserts both the quantity (`10`) and the on-disk line (`€ 10,00`, not `€10.00`) are preserved
- [x] Full test suite: 1002 passed
- [x] Manual smoke test on a European journal: status toggle via the edit form, date change via the edit form, amount unchanged through a clone