### PR TITLE
test(amountutil,hledger): multi-currency and precision edge cases

### DIFF
--- a/tests/test_amountutil.py
+++ b/tests/test_amountutil.py
@@ -153,3 +153,73 @@ class TestNormalizeNumberString:
     def test_plain_integer(self):
         """Plain integer with no separators passes through unchanged."""
         assert _normalize_number_string("3000") == "3000"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: precision, large amounts, multi-currency
+# ---------------------------------------------------------------------------
+
+
+class TestParseAmountStringEdgeCases:
+    """Precision, large amounts, and multi-currency edge cases."""
+
+    def test_nine_digit_us_amount(self):
+        """Parse a 9-digit US amount with three thousands separators."""
+        qty, commodity = parse_amount_string("999,999,999.99 USD")
+        assert qty == Decimal("999999999.99")
+        assert commodity == "USD"
+
+    def test_sub_cent_precision(self):
+        """Parse an amount with 3 decimal places (sub-cent)."""
+        qty, commodity = parse_amount_string("$0.001")
+        assert qty == Decimal("0.001")
+        assert commodity == "$"
+
+    def test_bitcoin_style_8_decimals(self):
+        """Parse a Bitcoin-style amount with 8 decimal places."""
+        qty, commodity = parse_amount_string("0.00100000 BTC")
+        assert qty == Decimal("0.00100000")
+        assert commodity == "BTC"
+
+    def test_negative_right_commodity(self):
+        """Parse a negative amount with right-side commodity."""
+        qty, commodity = parse_amount_string("-1,500.75 EUR")
+        assert qty == Decimal("-1500.75")
+        assert commodity == "EUR"
+
+    def test_integer_no_decimal(self):
+        """Parse an integer amount with no decimal point."""
+        qty, commodity = parse_amount_string("100 USD")
+        assert qty == Decimal("100")
+        assert commodity == "USD"
+
+    def test_european_nine_digit(self):
+        """Parse a large European amount: 999.999.999,99 EUR."""
+        qty, commodity = parse_amount_string("999.999.999,99 EUR")
+        assert qty == Decimal("999999999.99")
+        assert commodity == "EUR"
+
+
+class TestDecimalArithmeticInvariants:
+    """Decimal arithmetic properties relevant to budget rounding."""
+
+    def test_thirds_rounding(self):
+        """3 × 33.33 should equal 99.99, not 100 (no implicit rounding)."""
+        third = Decimal("33.33")
+        total = third * 3
+        assert total == Decimal("99.99")
+        assert total != Decimal("100")
+
+    def test_large_sum_precision(self):
+        """Sum of large Decimal values preserves full precision."""
+        a = Decimal("999999999.99")
+        b = Decimal("0.01")
+        assert a + b == Decimal("1000000000.00")
+
+    def test_negative_budget_delta(self):
+        """Negative minus positive stays negative (overspend scenario)."""
+        actual = Decimal("-200.00")
+        budget = Decimal("100.00")
+        delta = actual - budget
+        assert delta == Decimal("-300.00")
+        assert delta < 0

--- a/tests/test_hledger.py
+++ b/tests/test_hledger.py
@@ -1567,3 +1567,52 @@ class TestRunHledgerErrorHandling:
             lambda *args, **kwargs: (_ for _ in ()).throw(HledgerError("not found")),
         )
         assert get_hledger_version() == "?"
+
+
+class TestParseAmountPrecision:
+    """Multi-currency and precision edge cases for _parse_amount."""
+
+    def test_large_nine_digit_amount(self):
+        """A large 9-digit amount preserves magnitude and commodity."""
+        amt = _parse_amount(_amount_data("USD", 99999999999, 2))
+        assert amt.quantity == Decimal("999999999.99")
+        assert amt.commodity == "USD"
+
+    def test_zero_decimal_places(self):
+        """Integer amounts with zero decimal places remain whole numbers."""
+        amt = _parse_amount(_amount_data("EUR", 42, 0))
+        assert amt.quantity == Decimal("42")
+
+    def test_high_precision_crypto_8_places(self):
+        """Bitcoin-style 8-decimal amounts preserve their precision."""
+        amt = _parse_amount(_amount_data("BTC", 100000, 8, precision=8))
+        assert amt.quantity == Decimal("0.00100000")
+        assert amt.commodity == "BTC"
+
+    def test_negative_amount(self):
+        """Negative mantissas yield negative Decimal quantities."""
+        amt = _parse_amount(_amount_data("EUR", -15050, 2))
+        assert amt.quantity == Decimal("-150.50")
+
+    def test_european_comma_decimal_style(self):
+        """A European decimal mark is preserved in AmountStyle."""
+        amt = _parse_amount(_amount_data("EUR", 100000, 2, decimal_mark=",", precision=2))
+        assert amt.style.decimal_mark == ","
+        assert amt.quantity == Decimal("1000.00")
+
+    def test_right_side_commodity(self):
+        """A right-side commodity stays on the right in AmountStyle."""
+        amt = _parse_amount(_amount_data("EUR", 5000, 2, side="R"))
+        assert amt.style.commodity_side == "R"
+        assert amt.quantity == Decimal("50.00")
+
+    def test_multi_currency_conversion_posting(self):
+        """UnitCost with a foreign commodity stores total cost in the target commodity."""
+        btc_data = _amount_data("BTC", 50000000, 8)  # 0.5 BTC
+        eur_price = _amount_data("EUR", 2000000, 2)  # 20000.00 EUR per BTC
+        btc_data["acost"] = {"tag": "UnitCost", "contents": eur_price}
+        amt = _parse_amount(btc_data)
+        assert amt.commodity == "BTC"
+        assert amt.cost is not None
+        assert amt.cost.commodity == "EUR"
+        assert amt.cost.quantity == Decimal("10000.00")


### PR DESCRIPTION
Closes #137

## Changes
- **TestParseAmountStringEdgeCases** (6): 9-digit US/EU, sub-cent, BTC 8-decimal, negative right-commodity, integer
- **TestDecimalArithmeticInvariants** (3): 3×33.33=99.99, large sum precision, negative budget delta
- **TestParseAmountPrecision** (7): large mantissa, zero decimal places, crypto precision, negative, European comma style, right-side commodity, UnitCost multi-currency total