### PR TITLE
release: bump version to v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.2.14"
+version = "0.3.0"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.2.14"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary
- bump package version to 0.3.0
- refresh uv.lock for the release branch

## Validation
- uv run ruff check src tests
- uv run pytest