### PR TITLE
Update styles for nav-tabs and ContentSwitcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Thumbs.db
 
 # Backup files
 *.bak
+# Ignore all hledger journal files
+*.journal

--- a/src/hledger_textual/styles/app.tcss
+++ b/src/hledger_textual/styles/app.tcss
@@ -13,10 +13,11 @@ Screen {
 
 #nav-tabs Tab {
     padding: 0 2;
+    background: $boost;
 }
 
 #nav-tabs Tab.-active {
-    background: transparent;
+    border-bottom: solid $accent;
     text-style: bold;
 }
 
@@ -171,6 +172,7 @@ PaneToolbar {
     padding: 0 1;
     layout: horizontal;
     align: left middle;
+    background: $panel;
 }
 
 /* Generic filter-bar: show/hide only */

--- a/src/hledger_textual/styles/app.tcss
+++ b/src/hledger_textual/styles/app.tcss
@@ -6,6 +6,7 @@ Screen {
 
 /* --- App-lpadding-top: 1;evel layout --- */
 
+
 #nav-tabs {
     dock: top;
     margin: 1 0 0 0;
@@ -14,10 +15,13 @@ Screen {
 #nav-tabs Tab {
     padding: 0 2;
     background: $boost;
+    border: none;
 }
 
+/* --- removed blank header --- */
 #nav-tabs Tab.-active {
-    border-bottom: solid $accent;
+    background: $surface;
+    color: $accent;
     text-style: bold;
 }
 


### PR DESCRIPTION
Fixes #147
Navigation Tabs: Added a boosted background to all tabs and a accent colored bottom border to the active tab. 

Pane Toolbar: Added a distinct panel background to PaneToolbar to visually separate the toolbar elements
