### PR TITLE
fix(transaction-form): better error message for unbalanced transaction

### DIFF
--- a/src/hledger_textual/screens/transaction_form.py
+++ b/src/hledger_textual/screens/transaction_form.py
@@ -716,8 +716,9 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                 if total != 0:
                     commodity_sym = next(iter(commodities))
                     self.notify(
-                        f"Transaction is unbalanced (sum: {total:+g} {commodity_sym}). "
-                        "Negate one amount or leave one blank to auto-balance.",
+                        f"Transaction is unbalanced. Sum: {total:+g} {commodity_sym}. "
+                        "Tip: leave one amount blank to auto-balance, or add a "
+                        "posting to absorb the difference.",
                         severity="error",
                         timeout=6,
                     )

--- a/tests/test_transaction_form.py
+++ b/tests/test_transaction_form.py
@@ -368,6 +368,18 @@ class TestBalanceValidation:
             # Form must NOT have dismissed — still showing the form
             assert isinstance(app.screen, TransactionFormScreen)
 
+            # Toast must mention BOTH the imbalance amount and a concrete fix.
+            messages = [str(n.message) for n in app._notifications]
+            unbalanced = [m for m in messages if "unbalanced" in m]
+            assert unbalanced, (
+                f"expected an 'unbalanced' notification, got: {messages}"
+            )
+            msg = unbalanced[-1]
+            assert "200" in msg, f"missing imbalance amount in: {msg!r}"
+            assert "blank to auto-balance" in msg, (
+                f"missing actionable fix tip in: {msg!r}"
+            )
+
     async def test_balanced_same_commodity_is_accepted(self, app: HledgerTuiApp):
         from textual.widgets import Input
 


### PR DESCRIPTION
## Summary

Closes #154. Updates the unbalanced-transaction toast in `src/hledger_textual/screens/transaction_form.py:718-723` to match the actionable phrasing from the issue, and tightens the existing `test_unbalanced_same_commodity_is_rejected` test to assert the new copy contains both the imbalance amount and the fix tip.

## Why this matters

The previous message — "Transaction is unbalanced (sum: +5.00 EUR). Negate one amount or leave one blank to auto-balance." — names the imbalance but the fix advice is terse. The issue asks for the fix to be both visible and concrete:

> Transaction is unbalanced. Sum: +5.00 EUR.
> Tip: leave one amount blank to auto-balance, or add a posting to absorb the difference.

That's what this PR ships verbatim (modulo Textual's flat-toast formatting; the tip is still in the same notification body). Two posting rows are the common case; "negate one amount" is unhelpful when the user typed two same-sign amounts on purpose and wants a third absorbing posting. Mentioning "add a posting" gives the user a path other than mutating an existing line.

## Changes

- `src/hledger_textual/screens/transaction_form.py:718-723` — message rewritten. Imbalance amount and currency stay in the first sentence so toasts can be parsed/searched easily; the tip moves to a leading "Tip:" so users can scan past on repeat hits.
- `tests/test_transaction_form.py:348-378` — `test_unbalanced_same_commodity_is_rejected` now (a) keeps the existing "form not dismissed" assertion and (b) reads `app._notifications` (matching the existing pattern in `tests/test_app.py:217-220`) to assert the latest toast contains `"200"` (sum of the two `100.00` postings) AND the literal `"blank to auto-balance"` fix-tip phrase.

## Acceptance criteria

- [x] Error mentions both the imbalance amount AND a concrete fix.
- [x] Test in `tests/test_transaction_form.py` asserts the new copy.

## Testing

- `pytest tests/test_transaction_form.py::TestBalanceValidation::test_unbalanced_same_commodity_is_rejected` — runs as `SKIPPED` locally because `hledger` isn't installed (matches the rest of the file). The assertions execute end-to-end in CI environments that have `hledger` on PATH; I verified the message change by code inspection against the existing `app._notifications` capture pattern from `tests/test_app.py:215-220`.
- The unrelated `tests/test_git.py::test_sync_commits_and_pushes` failure also reproduces on `upstream/main`; not introduced by this PR.

This contribution was developed with AI assistance (Codex).
