### PR TITLE
fix: European commodity amount parsing

### DIFF
--- a/src/hledger_textual/amountutil.py
+++ b/src/hledger_textual/amountutil.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from decimal import Decimal, InvalidOperation
 
+from hledger_textual.models import AmountStyle
+
 
 def _normalize_number_string(s: str) -> str:
     """Normalize a raw number string to standard decimal notation.
@@ -49,6 +51,74 @@ def _normalize_number_string(s: str) -> str:
         normalized = core
 
     return f"-{normalized}" if negative else normalized
+
+
+def normalize_number_string_for_style(s: str, style: AmountStyle | None = None) -> str:
+    """Normalize a number string using a known commodity style when available.
+
+    Args:
+        s: A raw number string, optionally prefixed with a minus sign.
+        style: The style declared for the active commodity.
+
+    Returns:
+        The number string in standard ``Decimal``-parseable notation.
+    """
+    if style is None:
+        return _normalize_number_string(s)
+
+    negative = s.startswith("-")
+    core = s[1:] if negative else s
+    decimal_mark = style.decimal_mark or "."
+    group_separator = style.digit_group_separator
+
+    if decimal_mark != "." and decimal_mark in core:
+        if group_separator:
+            core = core.replace(group_separator, "")
+        normalized = core.replace(decimal_mark, ".")
+    elif "." in core and "," not in core:
+        # Users often type dot decimals even in comma-decimal journals.  Treat
+        # a lone dot followed by one or two digits as a decimal mark rather
+        # than the commodity's group mark.
+        after_last_dot = core[core.rfind(".") + 1:]
+        if group_separator == "." and len(after_last_dot) == 3:
+            normalized = core.replace(".", "")
+        else:
+            normalized = core
+    elif group_separator:
+        normalized = core.replace(group_separator, "")
+    else:
+        normalized = _normalize_number_string(core)
+
+    return f"-{normalized}" if negative else normalized
+
+
+def decimal_places_for_number_string(s: str, style: AmountStyle | None = None) -> int:
+    """Return decimal places from a raw number string.
+
+    Args:
+        s: A raw number string, optionally prefixed with a minus sign.
+        style: The style declared for the active commodity.
+
+    Returns:
+        Number of explicit fractional digits in the input.
+    """
+    core = s[1:] if s.startswith("-") else s
+    if style is not None and style.decimal_mark in core:
+        return len(core.rsplit(style.decimal_mark, 1)[1])
+    if "." in core and "," not in core:
+        if style is not None and style.digit_group_separator == ".":
+            after_last_dot = core[core.rfind(".") + 1:]
+            if len(after_last_dot) == 3:
+                return 0
+        return len(core.rsplit(".", 1)[1])
+    if "," in core and "." not in core:
+        after_last_comma = core[core.rfind(",") + 1:]
+        if len(after_last_comma) <= 2 and after_last_comma.isdigit():
+            return len(after_last_comma)
+    if "." in core and "," in core:
+        separator = "," if core.rfind(",") > core.rfind(".") else "."
+        return len(core.rsplit(separator, 1)[1])
+    return 0
 
 
 def parse_amount_string(s: str) -> tuple[Decimal, str]:

--- a/src/hledger_textual/screens/transaction_form.py
+++ b/src/hledger_textual/screens/transaction_form.py
@@ -15,6 +15,10 @@ from textual.screen import ModalScreen
 from textual.suggester import SuggestFromList
 from textual.widgets import Button, Input, Label, Select, Static
 
+from hledger_textual.amountutil import (
+    decimal_places_for_number_string,
+    normalize_number_string_for_style,
+)
 from hledger_textual.config import load_default_commodity
 from hledger_textual.hledger import (
     HledgerError,
@@ -42,24 +46,117 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _SYM = r"[€$£¥₿₹]"
 _NAME = r"[A-Za-z][A-Za-z0-9.]*"
 _COMMODITY = rf"(?:{_SYM}|{_NAME})"
-_UNSIGNED_QTY = r"\d+(?:\.\d+)?"
-_SIGNED_QTY = r"-?\d+(?:\.\d+)?"
+_UNSIGNED_QTY = r"\d+(?:[.,]\d+)*(?:[.,]\d+)?"
+_SIGNED_QTY = r"-?\d+(?:[.,]\d+)*(?:[.,]\d+)?"
 
 # -5.00 XEON @@ €742.59  OR  -5.00 XEON @ €148.518
 _AMOUNT_COST_RE = re.compile(rf"^({_SIGNED_QTY})\s+({_COMMODITY})\s+(@@?)\s+(.+)$")
 # -5.00 XEON  OR  5 USD
 _AMOUNT_QTY_COMM_RE = re.compile(rf"^({_SIGNED_QTY})\s+({_COMMODITY})\s*$")
-# €742.59  OR  -€742.59
-_AMOUNT_SYM_QTY_RE = re.compile(rf"^(-?)({_SYM})({_UNSIGNED_QTY})\s*$")
+# €742.59, EUR 742.59, -€742.59, OR -EUR 742.59
+_AMOUNT_COMM_QTY_RE = re.compile(rf"^(-?)({_COMMODITY})\s*({_UNSIGNED_QTY})\s*$")
+_COMMODITY_DIRECTIVE_RE = re.compile(r"^\s*commodity\s+(.+?)\s*$")
 
 
-def _decimal_places(qty_str: str) -> int:
+def _decimal_places(qty_str: str, style: AmountStyle | None = None) -> int:
     """Return the number of decimal places in a numeric string."""
-    return len(qty_str.split(".")[1]) if "." in qty_str else 0
+    return decimal_places_for_number_string(qty_str, style)
+
+
+def _amount_style_from_parts(
+    *,
+    commodity_side: str,
+    commodity_spaced: bool,
+    precision: int,
+    base_style: AmountStyle | None = None,
+) -> AmountStyle:
+    """Build an amount style, preserving locale separators from a base style."""
+    return AmountStyle(
+        commodity_side=commodity_side,
+        commodity_spaced=commodity_spaced,
+        decimal_mark=base_style.decimal_mark if base_style else ".",
+        digit_group_separator=base_style.digit_group_separator if base_style else None,
+        digit_group_sizes=list(base_style.digit_group_sizes) if base_style else [],
+        precision=max(precision, base_style.precision) if base_style else precision,
+    )
+
+
+def _parse_decimal(qty_str: str, style: AmountStyle | None = None) -> Decimal:
+    """Parse a quantity string according to a commodity style."""
+    return Decimal(normalize_number_string_for_style(qty_str, style))
+
+
+def _parse_commodity_directive_amount(amount_str: str) -> tuple[str, AmountStyle] | None:
+    """Parse a ``commodity`` directive sample amount into commodity and style."""
+    amount_str = amount_str.strip()
+
+    match = _AMOUNT_COMM_QTY_RE.match(amount_str)
+    if match:
+        _sign, commodity, qty_str = match.groups()
+        decimal_mark = "," if "," in qty_str and qty_str.rfind(",") > qty_str.rfind(".") else "."
+        other_separator = "." if decimal_mark == "," else ","
+        return (
+            commodity,
+            AmountStyle(
+                commodity_side="L",
+                commodity_spaced=True,
+                decimal_mark=decimal_mark,
+                digit_group_separator=other_separator if other_separator in qty_str else None,
+                digit_group_sizes=[3] if other_separator in qty_str else [],
+                precision=_decimal_places(qty_str),
+            ),
+        )
+
+    match = _AMOUNT_QTY_COMM_RE.match(amount_str)
+    if match:
+        qty_str, commodity = match.groups()
+        decimal_mark = "," if "," in qty_str and qty_str.rfind(",") > qty_str.rfind(".") else "."
+        other_separator = "." if decimal_mark == "," else ","
+        return (
+            commodity,
+            AmountStyle(
+                commodity_side="R",
+                commodity_spaced=True,
+                decimal_mark=decimal_mark,
+                digit_group_separator=other_separator if other_separator in qty_str else None,
+                digit_group_sizes=[3] if other_separator in qty_str else [],
+                precision=_decimal_places(qty_str),
+            ),
+        )
+
+    return None
+
+
+def load_journal_commodity_styles(file: Path) -> dict[str, AmountStyle]:
+    """Load commodity styles declared directly in a journal file.
+
+    Args:
+        file: Path to the journal file.
+
+    Returns:
+        Mapping of commodity name to declared amount style.
+    """
+    try:
+        lines = file.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+
+    styles: dict[str, AmountStyle] = {}
+    for line in lines:
+        match = _COMMODITY_DIRECTIVE_RE.match(line)
+        if not match:
+            continue
+        parsed = _parse_commodity_directive_amount(match.group(1).split(";", 1)[0])
+        if parsed is None:
+            continue
+        commodity, style = parsed
+        styles[commodity] = style
+    return styles
 
 
 def _extract_commodity_and_qty(
     s: str,
+    commodity_styles: dict[str, AmountStyle] | None = None,
 ) -> tuple[Decimal, str, Decimal | None] | None:
     """Extract signed quantity, commodity name, and optional total proceeds.
 
@@ -83,9 +180,9 @@ def _extract_commodity_and_qty(
         qty_str, commodity, at_sign, cost_str = (
             m.group(1), m.group(2), m.group(3), m.group(4)
         )
-        qty = Decimal(qty_str)
+        qty = _parse_decimal(qty_str, (commodity_styles or {}).get(commodity))
         proceeds: Decimal | None = None
-        cost_amount = _parse_simple_amount_str(cost_str.strip(), "")
+        cost_amount = _parse_simple_amount_str(cost_str.strip(), "", commodity_styles)
         if cost_amount is not None:
             if at_sign == "@":
                 proceeds = abs(cost_amount.quantity) * abs(qty)
@@ -95,7 +192,7 @@ def _extract_commodity_and_qty(
     m = _AMOUNT_QTY_COMM_RE.match(s)
     if m:
         qty_str, commodity = m.groups()
-        return Decimal(qty_str), commodity, None
+        return _parse_decimal(qty_str, (commodity_styles or {}).get(commodity)), commodity, None
     return None
 
 
@@ -150,7 +247,11 @@ def _build_commodity_data(
     return result
 
 
-def _parse_simple_amount_str(s: str, default_commodity: str) -> Amount | None:
+def _parse_simple_amount_str(
+    s: str,
+    default_commodity: str,
+    commodity_styles: dict[str, AmountStyle] | None = None,
+) -> Amount | None:
     """Parse a simple hledger amount string (no cost annotation).
 
     Handles: ``€742.59``, ``-€742.59``, ``-5.00 XEON``, ``742.59``.
@@ -158,41 +259,57 @@ def _parse_simple_amount_str(s: str, default_commodity: str) -> Amount | None:
     """
     s = s.strip()
 
-    m = _AMOUNT_SYM_QTY_RE.match(s)
+    commodity_styles = commodity_styles or {}
+
+    m = _AMOUNT_COMM_QTY_RE.match(s)
     if m:
-        sign, sym, qty_str = m.groups()
-        qty = Decimal(f"{sign}{qty_str}")
-        style = AmountStyle(
+        sign, commodity, qty_str = m.groups()
+        base_style = commodity_styles.get(commodity)
+        qty = _parse_decimal(f"{sign}{qty_str}", base_style)
+        style = _amount_style_from_parts(
             commodity_side="L",
-            commodity_spaced=False,
-            precision=max(_decimal_places(qty_str), 2),
+            commodity_spaced=bool(base_style and base_style.commodity_spaced) or len(commodity) > 1,
+            precision=max(_decimal_places(qty_str, base_style), 2 if len(commodity) == 1 else 0),
+            base_style=base_style,
         )
-        return Amount(commodity=sym, quantity=qty, style=style)
+        return Amount(commodity=commodity, quantity=qty, style=style)
 
     m = _AMOUNT_QTY_COMM_RE.match(s)
     if m:
         qty_str, commodity = m.groups()
-        qty = Decimal(qty_str)
-        style = AmountStyle(
-            commodity_side="R",
-            commodity_spaced=True,
-            precision=_decimal_places(qty_str),
+        base_style = commodity_styles.get(commodity)
+        qty = _parse_decimal(qty_str, base_style)
+        style = _amount_style_from_parts(
+            commodity_side=base_style.commodity_side if base_style else "R",
+            commodity_spaced=base_style.commodity_spaced if base_style else True,
+            precision=_decimal_places(qty_str, base_style),
+            base_style=base_style,
         )
         return Amount(commodity=commodity, quantity=qty, style=style)
 
     try:
-        qty = Decimal(s)
-        style = AmountStyle(
-            commodity_side="L" if not default_commodity[:1].isdigit() else "R",
-            commodity_spaced=len(default_commodity) > 1,
-            precision=max(_decimal_places(s), 2),
+        base_style = commodity_styles.get(default_commodity)
+        qty = _parse_decimal(s, base_style)
+        style = _amount_style_from_parts(
+            commodity_side=base_style.commodity_side
+            if base_style
+            else "L"
+            if not default_commodity[:1].isdigit()
+            else "R",
+            commodity_spaced=base_style.commodity_spaced if base_style else len(default_commodity) > 1,
+            precision=max(_decimal_places(s, base_style), 2),
+            base_style=base_style,
         )
         return Amount(commodity=default_commodity, quantity=qty, style=style)
     except InvalidOperation:
         return None
 
 
-def parse_amount_str(s: str, default_commodity: str) -> Amount | None:
+def parse_amount_str(
+    s: str,
+    default_commodity: str,
+    commodity_styles: dict[str, AmountStyle] | None = None,
+) -> Amount | None:
     """Parse a hledger amount string including an optional cost annotation.
 
     Supports:
@@ -208,17 +325,20 @@ def parse_amount_str(s: str, default_commodity: str) -> Amount | None:
     s = s.strip()
     if not s:
         return None
+    commodity_styles = commodity_styles or {}
 
     m = _AMOUNT_COST_RE.match(s)
     if m:
         qty_str, commodity, at_sign, cost_str = m.groups()
-        qty = Decimal(qty_str)
-        style = AmountStyle(
-            commodity_side="R",
-            commodity_spaced=True,
-            precision=_decimal_places(qty_str),
+        base_style = commodity_styles.get(commodity)
+        qty = _parse_decimal(qty_str, base_style)
+        style = _amount_style_from_parts(
+            commodity_side=base_style.commodity_side if base_style else "R",
+            commodity_spaced=base_style.commodity_spaced if base_style else True,
+            precision=_decimal_places(qty_str, base_style),
+            base_style=base_style,
         )
-        cost_amount = _parse_simple_amount_str(cost_str.strip(), default_commodity)
+        cost_amount = _parse_simple_amount_str(cost_str.strip(), default_commodity, commodity_styles)
         if cost_amount is None:
             return None
         if at_sign == "@":
@@ -236,7 +356,7 @@ def parse_amount_str(s: str, default_commodity: str) -> Amount | None:
             )
         return Amount(commodity=commodity, quantity=qty, style=style, cost=cost_amount)
 
-    return _parse_simple_amount_str(s, default_commodity)
+    return _parse_simple_amount_str(s, default_commodity, commodity_styles)
 
 STATUS_OPTIONS = [
     ("Unmarked", TransactionStatus.UNMARKED),
@@ -272,6 +392,15 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         self.posting_count = 0
         self.accounts: list[str] = []
         self.commodity_data: dict[str, tuple[Decimal, Decimal, str]] = {}
+        self.commodity_styles: dict[str, AmountStyle] = load_journal_commodity_styles(self.journal_file)
+
+    @property
+    def default_commodity(self) -> str:
+        """Return the form's default commodity."""
+        configured = load_default_commodity()
+        if configured != "$" or not self.commodity_styles:
+            return configured
+        return next(iter(self.commodity_styles))
 
     @property
     def _has_template(self) -> bool:
@@ -352,7 +481,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                     id="postings-hint",
                 )
                 yield Static(
-                    f"Default commodity: {load_default_commodity()}",
+                    f"Default commodity: {self.default_commodity}",
                     id="default-commodity-hint",
                 )
                 yield Vertical(id="postings-container")
@@ -387,7 +516,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         if self._has_template:
             for i, posting in enumerate(self.transaction.postings):
                 amount_str = ""
-                commodity = load_default_commodity()
+                commodity = self.default_commodity
                 if posting.amounts:
                     amt = posting.amounts[0]
                     if amt.cost is not None:
@@ -405,7 +534,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                     initial_amounts=posting.amounts if posting.amounts else None,
                 )
         else:
-            default_commodity = load_default_commodity()
+            default_commodity = self.default_commodity
             self._add_posting_row(label="#1:", commodity=default_commodity)
             self._add_posting_row(label="#2:", commodity=default_commodity)
 
@@ -422,7 +551,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         if not label:
             label = f"#{self.posting_count + 1}:"
         if not commodity:
-            commodity = load_default_commodity()
+            commodity = self.default_commodity
         row = PostingRow(
             label=label,
             account=account,
@@ -465,7 +594,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         container = self.query_one("#postings-container", Vertical)
         for row in container.query(PostingRow):
             amount_input = row.query_one(f"#amount-{row.row_index}", Input)
-            parsed = _extract_commodity_and_qty(amount_input.value)
+            parsed = _extract_commodity_and_qty(amount_input.value, self.commodity_styles)
             if parsed:
                 qty, commodity, proceeds = parsed
                 hint = self._build_cost_hint(commodity, qty, proceeds)
@@ -527,7 +656,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         if not event.input.id or not event.input.id.startswith("amount-"):
             return
         hint_widget = self.query_one("#cost-basis-hint", Static)
-        parsed = _extract_commodity_and_qty(event.value)
+        parsed = _extract_commodity_and_qty(event.value, self.commodity_styles)
         if parsed:
             qty, commodity, proceeds = parsed
             hint = self._build_cost_hint(commodity, qty, proceeds)
@@ -686,8 +815,8 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                 if reused is not None:
                     amounts.extend(reused)
                 else:
-                    default_commodity = row.commodity or load_default_commodity()
-                    amount = parse_amount_str(row.amount, default_commodity)
+                    default_commodity = row.commodity or self.default_commodity
+                    amount = parse_amount_str(row.amount, default_commodity, self.commodity_styles)
                     if amount is None:
                         self.notify(
                             f"Invalid amount: \"{row.amount}\". "

--- a/tests/test_transaction_form.py
+++ b/tests/test_transaction_form.py
@@ -14,6 +14,7 @@ from hledger_textual.screens.transaction_form import (
     TransactionFormScreen,
     _build_commodity_data,
     _extract_commodity_and_qty,
+    load_journal_commodity_styles,
     parse_amount_str,
 )
 from hledger_textual.widgets.amount_input import AmountInput
@@ -489,6 +490,135 @@ class TestEuropeanStylePreservation:
         assert "€10.00" not in file_text
 
 
+class TestEuropeanNewTransactionParsing:
+    """Regression tests for issues #167 and #195."""
+
+    @pytest.fixture
+    def european_eur_journal(self, tmp_path: Path) -> Path:
+        content = (
+            "commodity EUR 1.000,00\n"
+            "\n"
+            f"{_D1.isoformat()} Opening\n"
+            "    assets:bank      EUR 1,00\n"
+            "    equity:opening\n"
+        )
+        dest = tmp_path / "european-eur.journal"
+        dest.write_text(content)
+        return dest
+
+    @pytest.fixture
+    def european_eur_app(self, european_eur_journal: Path) -> HledgerTuiApp:
+        return HledgerTuiApp(journal_file=european_eur_journal)
+
+    async def test_new_transaction_uses_journal_commodity_as_default(
+        self,
+        european_eur_app: HledgerTuiApp,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Plain numbers use the commodity declared by the journal."""
+        from textual.widgets import Input
+
+        monkeypatch.setattr(
+            "hledger_textual.screens.transaction_form.load_default_commodity",
+            lambda: "$",
+        )
+
+        async with european_eur_app.run_test(size=(100, 60)) as pilot:
+            await pilot.pause()
+            await pilot.press("2")
+            await pilot.pause(delay=0.5)
+            await pilot.press("a")
+            await pilot.pause(delay=0.5)
+            form = european_eur_app.screen
+            assert isinstance(form, TransactionFormScreen)
+            captured: list = []
+            form.dismiss = captured.append
+
+            form.query_one("#input-description", Input).value = "Default commodity test"
+            rows = list(form.query(PostingRow))
+            rows[0].query_one("#account-0", Input).value = "expenses:food"
+            rows[0].query_one("#amount-0", Input).value = "1,00"
+            rows[1].query_one("#account-1", Input).value = "assets:bank"
+            form._save()
+            await pilot.pause(delay=1.0)
+
+            assert captured
+            transaction = captured[0]
+            assert transaction is not None
+            amount = transaction.postings[0].amounts[0]
+            assert amount.commodity == "EUR"
+            assert amount.quantity == Decimal("1.00")
+            assert amount.format() == "EUR 1,00"
+
+    async def test_new_transaction_accepts_left_named_commodity(
+        self,
+        european_eur_app: HledgerTuiApp,
+    ):
+        """Named commodities are accepted before the number."""
+        from textual.widgets import Input
+
+        async with european_eur_app.run_test(size=(100, 60)) as pilot:
+            await pilot.pause()
+            await pilot.press("2")
+            await pilot.pause(delay=0.5)
+            await pilot.press("a")
+            await pilot.pause(delay=0.5)
+            form = european_eur_app.screen
+            assert isinstance(form, TransactionFormScreen)
+            captured: list = []
+            form.dismiss = captured.append
+
+            form.query_one("#input-description", Input).value = "Left commodity test"
+            rows = list(form.query(PostingRow))
+            rows[0].query_one("#account-0", Input).value = "expenses:food"
+            rows[0].query_one("#amount-0", Input).value = "EUR 5"
+            rows[1].query_one("#account-1", Input).value = "assets:bank"
+            form._save()
+            await pilot.pause(delay=1.0)
+
+            assert captured
+            transaction = captured[0]
+            assert transaction is not None
+            amount = transaction.postings[0].amounts[0]
+            assert amount.commodity == "EUR"
+            assert amount.quantity == Decimal("5")
+            assert amount.format() == "EUR 5,00"
+
+    async def test_new_transaction_dot_decimal_is_not_group_separator(
+        self,
+        european_eur_app: HledgerTuiApp,
+    ):
+        """A lone dot remains a decimal separator for user input."""
+        from textual.widgets import Input
+
+        async with european_eur_app.run_test(size=(100, 60)) as pilot:
+            await pilot.pause()
+            await pilot.press("2")
+            await pilot.pause(delay=0.5)
+            await pilot.press("a")
+            await pilot.pause(delay=0.5)
+            form = european_eur_app.screen
+            assert isinstance(form, TransactionFormScreen)
+            captured: list = []
+            form.dismiss = captured.append
+
+            form.query_one("#input-description", Input).value = "Dot decimal test"
+            rows = list(form.query(PostingRow))
+            rows[0].query_one("#account-0", Input).value = "expenses:food"
+            rows[0].query_one("#amount-0", Input).value = "5.5 EUR"
+            rows[1].query_one("#account-1", Input).value = "assets:bank"
+            form._save()
+            await pilot.pause(delay=1.0)
+
+            assert captured
+            transaction = captured[0]
+            assert transaction is not None
+            amount = transaction.postings[0].amounts[0]
+            assert amount.commodity == "EUR"
+            assert amount.quantity == Decimal("5.5")
+            assert amount.format() == "EUR 5,50"
+
+
 class TestDateValidation:
     """Tests for the _validate_date method directly."""
 
@@ -868,6 +998,92 @@ class TestParseAmountStr:
         assert amt.cost.quantity == Decimal("200.00")
         # format() must produce a valid hledger string (positive cost)
         assert amt.format() == "-10 STCK @@ €200.00"
+
+    def test_european_decimal_comma_with_default_commodity(self):
+        """European decimal commas parse without scaling by 100."""
+        styles = {
+            "EUR": AmountStyle(
+                commodity_side="L",
+                commodity_spaced=True,
+                decimal_mark=",",
+                digit_group_separator=".",
+                digit_group_sizes=[3],
+                precision=2,
+            )
+        }
+        amt = parse_amount_str("1,00", "EUR", styles)
+        assert amt is not None
+        assert amt.commodity == "EUR"
+        assert amt.quantity == Decimal("1.00")
+        assert amt.format() == "EUR 1,00"
+
+    def test_left_named_commodity_prefix(self):
+        """Named commodities can appear before the quantity."""
+        styles = {
+            "EUR": AmountStyle(
+                commodity_side="L",
+                commodity_spaced=True,
+                decimal_mark=",",
+                digit_group_separator=".",
+                digit_group_sizes=[3],
+                precision=2,
+            )
+        }
+        amt = parse_amount_str("EUR 5", "$", styles)
+        assert amt is not None
+        assert amt.commodity == "EUR"
+        assert amt.quantity == Decimal("5")
+        assert amt.format() == "EUR 5,00"
+
+    def test_dot_decimal_with_european_commodity_style(self):
+        """A lone dot in user input is parsed as decimal, not grouping."""
+        styles = {
+            "EUR": AmountStyle(
+                commodity_side="L",
+                commodity_spaced=True,
+                decimal_mark=",",
+                digit_group_separator=".",
+                digit_group_sizes=[3],
+                precision=2,
+            )
+        }
+        amt = parse_amount_str("5.5 EUR", "$", styles)
+        assert amt is not None
+        assert amt.commodity == "EUR"
+        assert amt.quantity == Decimal("5.5")
+        assert amt.format() == "EUR 5,50"
+
+    def test_european_thousands_separator_still_parses_as_grouping(self):
+        """Three digits after the group separator remain a thousands group."""
+        styles = {
+            "EUR": AmountStyle(
+                commodity_side="L",
+                commodity_spaced=True,
+                decimal_mark=",",
+                digit_group_separator=".",
+                digit_group_sizes=[3],
+                precision=2,
+            )
+        }
+        amt = parse_amount_str("1.000 EUR", "$", styles)
+        assert amt is not None
+        assert amt.commodity == "EUR"
+        assert amt.quantity == Decimal("1000")
+        assert amt.format() == "EUR 1.000,00"
+
+    def test_loads_commodity_style_from_journal_directive(self, tmp_path: Path):
+        """Commodity directives provide the parser's default style."""
+        journal = tmp_path / "test.journal"
+        journal.write_text("commodity EUR 1.000,00\n")
+        styles = load_journal_commodity_styles(journal)
+        assert styles["EUR"] == AmountStyle(
+            commodity_side="L",
+            commodity_spaced=True,
+            decimal_mark=",",
+            digit_group_separator=".",
+            digit_group_sizes=[3],
+            precision=2,
+        )
 
 
 class TestExtractCommodityAndQty:


### PR DESCRIPTION
## Summary
- parse transaction form amounts using commodity directive decimal/grouping styles
- accept named commodities before the quantity, such as `EUR 5`
- use the journal commodity directive as the default commodity when config still uses the fallback
- add regression coverage for European decimal commas, dot decimal user input, and grouped thousands

## Verification
- `uv run ruff check src/hledger_textual/amountutil.py src/hledger_textual/screens/transaction_form.py tests/test_transaction_form.py`
- `uv run pytest tests/test_transaction_form.py tests/test_amountutil.py --no-cov`
- `uv run pytest` (`1135 passed`, coverage `77.98%`)

Closes #167
Closes #195