### PR TITLE
chore: prepare v0.3.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.3.3"
+version = "0.3.4"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -163,16 +163,25 @@ class TestRefresh:
 class TestDelete:
     """Tests for the delete flow."""
 
+    async def _wait_for_delete_modal(self, app: HledgerTuiApp, pilot):
+        """Wait for the delete confirmation modal to become active."""
+        from hledger_textual.screens.delete_confirm import DeleteConfirmModal
+
+        for _ in range(10):
+            if isinstance(app.screen, DeleteConfirmModal):
+                return app.screen
+            await pilot.pause(delay=0.1)
+
+        assert isinstance(app.screen, DeleteConfirmModal)
+        return app.screen
+
     async def test_delete_shows_modal(self, app: HledgerTuiApp):
         async with app.run_test() as pilot:
             await pilot.pause()
             await pilot.press("2")
             await pilot.pause(delay=0.5)
             await pilot.press("d")
-            await pilot.pause()
-            from hledger_textual.screens.delete_confirm import DeleteConfirmModal
-
-            assert isinstance(app.screen, DeleteConfirmModal)
+            await self._wait_for_delete_modal(app, pilot)
 
     async def test_delete_cancel(self, app: HledgerTuiApp):
         async with app.run_test() as pilot:
@@ -180,7 +189,7 @@ class TestDelete:
             await pilot.press("2")
             await pilot.pause(delay=0.5)
             await pilot.press("d")
-            await pilot.pause()
+            await self._wait_for_delete_modal(app, pilot)
             await pilot.press("escape")
             await pilot.pause(delay=0.5)
             table = app.screen.query_one("#transactions-table")
@@ -192,7 +201,7 @@ class TestDelete:
             await pilot.press("2")
             await pilot.pause(delay=0.5)
             await pilot.press("d")
-            await pilot.pause()
+            await self._wait_for_delete_modal(app, pilot)
             delete_btn = app.screen.query_one("#btn-delete")
             await pilot.click(delete_btn)
             await pilot.pause(delay=1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary
- Bump hledger-textual to 0.3.4 in pyproject.toml and uv.lock
- Stabilize the transaction delete modal integration test after the CI timing failure

## Verification
- uv run ruff check
- uv run pytest tests/test_app.py::TestDelete --no-cov
- uv run pytest
- uv build

## Notes
- PRs #194 and #196 have been merged.
- Issues #152, #167, and #195 are closed.
- Issue #191 is still open in milestone v0.3.4, so the milestone cannot be closed yet unless that issue is resolved or moved.