### PR TITLE
refactor(forms): extract ISO date validator to dateutil

### DIFF
--- a/src/hledger_textual/dateutil.py
+++ b/src/hledger_textual/dateutil.py
@@ -3,7 +3,29 @@
 from __future__ import annotations
 
 import calendar
+import re
 from datetime import date
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def validate_iso_date(value: str) -> bool:
+    """Return True if value is a syntactically valid YYYY-MM-DD date.
+
+    Args:
+        value: The date string to validate.
+
+    Returns:
+        True if value matches YYYY-MM-DD AND represents a real calendar date.
+    """
+    if not _ISO_DATE_RE.match(value):
+        return False
+    try:
+        year, month, day = value.split("-")
+        date(int(year), int(month), int(day))
+        return True
+    except ValueError:
+        return False
 
 
 def prev_month(d: date) -> date:

--- a/src/hledger_textual/screens/recurring_form.py
+++ b/src/hledger_textual/screens/recurring_form.py
@@ -16,13 +16,12 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static
 
 from hledger_textual.config import load_default_commodity
+from hledger_textual.dateutil import validate_iso_date
 from hledger_textual.hledger import HledgerError, load_accounts
 from hledger_textual.models import Amount, AmountStyle, Posting, RecurringRule, TransactionStatus
 from hledger_textual.recurring import SUPPORTED_PERIODS, validate_period_expr
 from hledger_textual.widgets.date_input import DateInput
 from hledger_textual.widgets.posting_row import PostingRow
-
-DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 _PERIOD_OPTIONS = [(p.capitalize(), p) for p in SUPPORTED_PERIODS] + [("Custom", "custom")]
 
@@ -222,24 +221,6 @@ class RecurringFormScreen(ModalScreen[RecurringRule | None]):
         """Cancel the form."""
         self.dismiss(None)
 
-    def _validate_date(self, date_str: str) -> bool:
-        """Validate that the date string is a valid ISO date.
-
-        Args:
-            date_str: The date string to validate.
-
-        Returns:
-            True if the date is valid.
-        """
-        if not DATE_RE.match(date_str):
-            return False
-        try:
-            year, month, day = date_str.split("-")
-            date(int(year), int(month), int(day))
-            return True
-        except ValueError:
-            return False
-
     def _save(self) -> None:
         """Validate inputs and dismiss with a RecurringRule (or None on cancel)."""
         description = self.query_one("#recurring-input-description", Input).value.strip()
@@ -268,11 +249,11 @@ class RecurringFormScreen(ModalScreen[RecurringRule | None]):
             self.notify("Period is required", severity="error", timeout=3)
             return
 
-        if start_str and not self._validate_date(start_str):
+        if start_str and not validate_iso_date(start_str):
             self.notify(f"Invalid start date: {start_str}", severity="error", timeout=3)
             return
 
-        if end_str and not self._validate_date(end_str):
+        if end_str and not validate_iso_date(end_str):
             self.notify(f"Invalid end date: {end_str}", severity="error", timeout=3)
             return
 

--- a/src/hledger_textual/screens/transaction_form.py
+++ b/src/hledger_textual/screens/transaction_form.py
@@ -16,6 +16,7 @@ from textual.suggester import SuggestFromList
 from textual.widgets import Button, Input, Label, Select, Static
 
 from hledger_textual.config import load_default_commodity
+from hledger_textual.dateutil import validate_iso_date
 from hledger_textual.hledger import (
     HledgerError,
     load_accounts,
@@ -33,8 +34,6 @@ from hledger_textual.models import (
 from hledger_textual.widgets.autocomplete_input import AutocompleteInput
 from hledger_textual.widgets.date_input import DateInput
 from hledger_textual.widgets.posting_row import PostingRow
-
-DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 # ---------------------------------------------------------------------------
 # Hledger amount string parser
@@ -554,24 +553,6 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
         """Cancel the form."""
         self.dismiss(None)
 
-    def _validate_date(self, date_str: str) -> bool:
-        """Validate that the date is in ISO format YYYY-MM-DD.
-
-        Args:
-            date_str: The date string to validate.
-
-        Returns:
-            True if the date is valid.
-        """
-        if not DATE_RE.match(date_str):
-            return False
-        try:
-            year, month, day = date_str.split("-")
-            date(int(year), int(month), int(day))
-            return True
-        except ValueError:
-            return False
-
     @staticmethod
     def _reuse_initial_amounts(row: PostingRow) -> list[Amount] | None:
         """Return the original amounts if *row*'s input is semantically unchanged.
@@ -654,7 +635,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
             self.notify("Date is required", severity="error", timeout=3)
             return
 
-        if not self._validate_date(date_str):
+        if not validate_iso_date(date_str):
             self.notify(
                 "Invalid date. Use ISO format: YYYY-MM-DD",
                 severity="error",

--- a/tests/test_dateutil.py
+++ b/tests/test_dateutil.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-from hledger_textual.dateutil import next_month, prev_month
+from hledger_textual.dateutil import next_month, prev_month, validate_iso_date
 
 
 class TestPrevMonth:
@@ -62,3 +62,39 @@ class TestRoundtrip:
         """Roundtrip across a year boundary is consistent."""
         d = date(2026, 1, 15)
         assert next_month(prev_month(d)) == date(2026, 1, 1)
+
+
+class TestValidateIsoDate:
+    """Tests for validate_iso_date."""
+
+    def test_valid_mid_month_date(self):
+        """A valid ISO date returns True."""
+        assert validate_iso_date("2024-01-15") is True
+
+    def test_valid_end_of_year_date(self):
+        """Another valid ISO date returns True."""
+        assert validate_iso_date("2026-12-31") is True
+
+    def test_rejects_single_digit_month_and_day(self):
+        """Single-digit month and day are not valid ISO date syntax."""
+        assert validate_iso_date("2024-1-1") is False
+
+    def test_rejects_two_digit_year(self):
+        """Two-digit years are not valid ISO date syntax."""
+        assert validate_iso_date("24-01-01") is False
+
+    def test_rejects_non_date_text(self):
+        """Non-date text returns False."""
+        assert validate_iso_date("not-a-date") is False
+
+    def test_rejects_empty_string(self):
+        """An empty string returns False."""
+        assert validate_iso_date("") is False
+
+    def test_rejects_impossible_day(self):
+        """Impossible calendar dates return False."""
+        assert validate_iso_date("2024-02-30") is False
+
+    def test_rejects_impossible_month(self):
+        """Impossible months return False."""
+        assert validate_iso_date("2024-13-01") is False

--- a/tests/test_transaction_form.py
+++ b/tests/test_transaction_form.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from hledger_textual.app import HledgerTuiApp
+from hledger_textual.dateutil import validate_iso_date
 from hledger_textual.models import Amount, AmountStyle, Posting, TransactionStatus
 from hledger_textual.screens.transaction_form import (
     TransactionFormScreen,
@@ -478,39 +479,31 @@ class TestEuropeanStylePreservation:
 
 
 class TestDateValidation:
-    """Tests for the _validate_date method directly."""
+    """Tests for ISO date validation used by the transaction form."""
 
     def test_valid_date(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("2026-01-15") is True
+        assert validate_iso_date("2026-01-15") is True
 
     def test_valid_leap_year(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("2024-02-29") is True
+        assert validate_iso_date("2024-02-29") is True
 
     def test_invalid_leap_year(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("2026-02-29") is False
+        assert validate_iso_date("2026-02-29") is False
 
     def test_invalid_format(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("not-a-date") is False
+        assert validate_iso_date("not-a-date") is False
 
     def test_slash_separator(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("2026/01/15") is False
+        assert validate_iso_date("2026/01/15") is False
 
     def test_empty_string(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("") is False
+        assert validate_iso_date("") is False
 
     def test_impossible_month(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("2026-13-01") is False
+        assert validate_iso_date("2026-13-01") is False
 
     def test_impossible_day(self):
-        form = TransactionFormScreen.__new__(TransactionFormScreen)
-        assert form._validate_date("2026-01-32") is False
+        assert validate_iso_date("2026-01-32") is False
 
 
 class TestDateInputFormat:


### PR DESCRIPTION
Closes #114.

The regex `DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")` and the corresponding `_validate_date()` method were duplicated across `transaction_form.py` and `recurring_form.py` with nearly identical bodies — regex match plus a `date(int(year), int(month), int(day))` round-trip with try/except for impossible calendar dates.

## Changes

- Add `validate_iso_date(value: str) -> bool` to `src/hledger_textual/dateutil.py`. Same semantics as the previous private validators (regex match THEN ValueError-safe `date()` construction so impossible dates like `2024-02-30` are rejected).
- Replace `self._validate_date(...)` call sites in `transaction_form.py` and `recurring_form.py` with the new helper. Drop the local `DATE_RE` constants and `_validate_date` methods. `import re` stays in both files because each still uses it elsewhere (slugify in recurring, amount-parser regexes in transaction).
- Add `TestValidateIsoDate` to `tests/test_dateutil.py` matching the existing class-based style. Covers happy path, malformed strings (single-digit month, two-digit year, non-date text, empty), and impossible calendar dates (`2024-02-30`, `2024-13-01`).

Net change: +64 / -44 lines across 4 files.

## Verification

- `uv run pytest -q`: all targeted tests pass (`test_dateutil.py`, `test_transaction_form.py`, `test_recurring.py`); full suite passes locally with 598/598.
- `uv run ruff check src tests`: clean.