### PR TITLE
refactor: extract FormAccountSuggestionsMixin for form screens

### DIFF
--- a/src/hledger_textual/screens/_form_account_suggestions.py
+++ b/src/hledger_textual/screens/_form_account_suggestions.py
@@ -1,0 +1,32 @@
+"""Shared account suggestion setup for form screens."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.suggester import SuggestFromList
+
+from hledger_textual.hledger import HledgerError, load_accounts
+from hledger_textual.widgets.autocomplete_input import AutocompleteInput
+
+
+class FormAccountSuggestionsMixin:
+    """Load journal accounts and optionally attach autocomplete suggestions."""
+
+    journal_file: Path
+    accounts: list[str]
+
+    def _configure_account_suggestions(self, *widget_ids: str) -> None:
+        """Load accounts into ``self.accounts`` and apply them to widget ids."""
+        try:
+            accounts = load_accounts(self.journal_file)
+        except HledgerError:
+            accounts = []
+
+        self.accounts = accounts
+        if not accounts:
+            return
+
+        suggester = SuggestFromList(accounts, case_sensitive=False)
+        for widget_id in widget_ids:
+            self.query_one(f"#{widget_id}", AutocompleteInput).suggester = suggester

--- a/src/hledger_textual/screens/budget_form.py
+++ b/src/hledger_textual/screens/budget_form.py
@@ -10,17 +10,16 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.suggester import SuggestFromList
 from textual.widgets import Button, Input, Label, Static
 
 from hledger_textual.config import load_default_commodity
-from hledger_textual.hledger import HledgerError, load_accounts
 from hledger_textual.models import Amount, AmountStyle, BudgetRule
+from hledger_textual.screens._form_account_suggestions import FormAccountSuggestionsMixin
 from hledger_textual.widgets.amount_input import NumericAmountInput
 from hledger_textual.widgets.autocomplete_input import AutocompleteInput
 
 
-class BudgetFormScreen(ModalScreen[BudgetRule | None]):
+class BudgetFormScreen(FormAccountSuggestionsMixin, ModalScreen[BudgetRule | None]):
     """Centered modal form for creating or editing a budget rule."""
 
     BINDINGS = [
@@ -99,17 +98,8 @@ class BudgetFormScreen(ModalScreen[BudgetRule | None]):
 
     def on_mount(self) -> None:
         """Load accounts for autocomplete."""
-        try:
-            accounts = load_accounts(self.journal_file)
-        except HledgerError:
-            accounts = []
-
-        self._known_accounts = accounts
-
-        if accounts:
-            self.query_one("#budget-input-account", AutocompleteInput).suggester = SuggestFromList(
-                accounts, case_sensitive=False
-            )
+        self._configure_account_suggestions("budget-input-account")
+        self._known_accounts = self.accounts
 
     def on_descendant_blur(self, event: events.DescendantBlur) -> None:
         """Warn when the account field is left holding an unknown name.

--- a/src/hledger_textual/screens/recurring_form.py
+++ b/src/hledger_textual/screens/recurring_form.py
@@ -16,9 +16,9 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static
 
 from hledger_textual.config import load_default_commodity
-from hledger_textual.hledger import HledgerError, load_accounts
 from hledger_textual.models import Amount, AmountStyle, Posting, RecurringRule, TransactionStatus
 from hledger_textual.recurring import SUPPORTED_PERIODS, validate_period_expr
+from hledger_textual.screens._form_account_suggestions import FormAccountSuggestionsMixin
 from hledger_textual.widgets.date_input import DateInput
 from hledger_textual.widgets.posting_row import PostingRow
 
@@ -43,7 +43,7 @@ def _slugify(text: str) -> str:
     return slug or "rule"
 
 
-class RecurringFormScreen(ModalScreen[RecurringRule | None]):
+class RecurringFormScreen(FormAccountSuggestionsMixin, ModalScreen[RecurringRule | None]):
     """Centered modal form for creating or editing a recurring rule."""
 
     BINDINGS = [
@@ -161,10 +161,7 @@ class RecurringFormScreen(ModalScreen[RecurringRule | None]):
 
     def on_mount(self) -> None:
         """Load accounts for autocomplete and populate posting rows."""
-        try:
-            self.accounts = load_accounts(self.journal_file)
-        except HledgerError:
-            self.accounts = []
+        self._configure_account_suggestions()
 
         # Hide custom expression row unless the period is already "custom"
         period_select = self.query_one("#recurring-select-period", Select)

--- a/src/hledger_textual/screens/transaction_form.py
+++ b/src/hledger_textual/screens/transaction_form.py
@@ -22,7 +22,6 @@ from hledger_textual.amountutil import (
 from hledger_textual.config import load_default_commodity
 from hledger_textual.hledger import (
     HledgerError,
-    load_accounts,
     load_descriptions,
     load_investment_cost,
     load_investment_positions,
@@ -34,6 +33,7 @@ from hledger_textual.models import (
     Transaction,
     TransactionStatus,
 )
+from hledger_textual.screens._form_account_suggestions import FormAccountSuggestionsMixin
 from hledger_textual.widgets.autocomplete_input import AutocompleteInput
 from hledger_textual.widgets.date_input import DateInput
 from hledger_textual.widgets.posting_row import PostingRow
@@ -365,7 +365,7 @@ STATUS_OPTIONS = [
 ]
 
 
-class TransactionFormScreen(ModalScreen[Transaction | None]):
+class TransactionFormScreen(FormAccountSuggestionsMixin, ModalScreen[Transaction | None]):
     """Centered modal form for creating or editing a transaction."""
 
     BINDINGS = [
@@ -497,10 +497,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
 
     def on_mount(self) -> None:
         """Load accounts and descriptions for autocomplete, and add initial posting rows."""
-        try:
-            self.accounts = load_accounts(self.journal_file)
-        except HledgerError:
-            self.accounts = []
+        self._configure_account_suggestions()
 
         try:
             descriptions = load_descriptions(self.journal_file)

--- a/tests/test_budget_form.py
+++ b/tests/test_budget_form.py
@@ -273,13 +273,10 @@ class TestBudgetFormUnknownAccountWarning:
 
     async def test_warns_when_account_unknown_after_blur(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Typing an unknown account and tabbing away shows the inline warning widget."""
-        from hledger_textual.screens import budget_form
-
         # Pretend the journal already knows about a couple of accounts so the
         # form has something to compare against.
         monkeypatch.setattr(
-            budget_form,
-            "load_accounts",
+            "hledger_textual.screens._form_account_suggestions.load_accounts",
             lambda _path: ["Expenses:Food", "Expenses:Rent", "Income:Salary"],
         )
 
@@ -309,11 +306,8 @@ class TestBudgetFormUnknownAccountWarning:
 
     async def test_no_warning_when_account_is_known(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Tabbing away from a known account keeps the inline warning hidden."""
-        from hledger_textual.screens import budget_form
-
         monkeypatch.setattr(
-            budget_form,
-            "load_accounts",
+            "hledger_textual.screens._form_account_suggestions.load_accounts",
             lambda _path: ["Expenses:Food", "Expenses:Rent"],
         )
 
@@ -336,9 +330,10 @@ class TestBudgetFormUnknownAccountWarning:
 
     async def test_no_warning_when_journal_has_no_accounts(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """If load_accounts returns nothing, blur leaves the warning hidden (fresh journal)."""
-        from hledger_textual.screens import budget_form
-
-        monkeypatch.setattr(budget_form, "load_accounts", lambda _path: [])
+        monkeypatch.setattr(
+            "hledger_textual.screens._form_account_suggestions.load_accounts",
+            lambda _path: [],
+        )
 
         app = _FormApp(tmp_path / "test.journal")
         async with app.run_test() as pilot:
@@ -361,11 +356,8 @@ class TestBudgetFormUnknownAccountWarning:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         """Fixing a typo to a known account hides the previously-shown warning on the next blur."""
-        from hledger_textual.screens import budget_form
-
         monkeypatch.setattr(
-            budget_form,
-            "load_accounts",
+            "hledger_textual.screens._form_account_suggestions.load_accounts",
             lambda _path: ["Expenses:Food", "Expenses:Rent"],
         )
 


### PR DESCRIPTION
Closes #117.

Adds `src/hledger_textual/screens/_form_account_suggestions.py` with a small `FormAccountSuggestionsMixin`. Each of `BudgetFormScreen`, `RecurringFormScreen`, and `TransactionFormScreen` now extends the mixin and replaces its hand-rolled `try/except load_accounts` block with `self._configure_account_suggestions(...)`.

The mixin loads accounts once into `self.accounts`, swallows `HledgerError` to keep the silent-empty-list fallback, and (when widget ids are passed) wires a `SuggestFromList` onto each. `BudgetFormScreen` keeps its `self._known_accounts` attribute (still used by the unknown-account warning logic) by aliasing it to `self.accounts` after the mixin call. The other two screens didn't wire a suggester at on_mount time, so they call the helper without arguments.

Other notes

- MRO: the mixin is placed before `ModalScreen` in each `class Foo(...)` declaration so the helper resolves first; no name collisions.
- Drops now-unused `HledgerError`, `load_accounts`, `SuggestFromList` imports per file.
- `tests/test_budget_form.py` patches `load_accounts` at the new `_form_account_suggestions` module path so the unknown-account warning suite continues to drive `BudgetFormScreen` exactly as before.
- Net diff: +49 / -41 across 5 files; full `uv run pytest -q` is 595 passed / 548 skipped (no new failures).