### PR TITLE
feat(forms): mark required fields with asterisks

### DIFF
--- a/src/hledger_textual/screens/budget_form.py
+++ b/src/hledger_textual/screens/budget_form.py
@@ -59,8 +59,8 @@ class BudgetFormScreen(ModalScreen[BudgetRule | None]):
             yield Static(title, id="budget-form-title")
 
             with Vertical(classes="form-field-group"):
-                with Horizontal(classes="form-field"):
-                    yield Label("Account:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Account:*")
                     yield AutocompleteInput(
                         value=self.rule.account if self.is_edit else "",
                         placeholder="e.g. Expenses:Groceries",
@@ -69,15 +69,15 @@ class BudgetFormScreen(ModalScreen[BudgetRule | None]):
 
                 yield Static("", id="budget-account-warning", classes="field-warning hidden")
 
-            with Horizontal(classes="form-field"):
-                yield Label("Amount:")
+            with Horizontal(classes="form-field form-field--required"):
+                yield Label("Amount:*")
                 yield NumericAmountInput(
                     value=f"{self.rule.amount.quantity:.2f}" if self.is_edit else "",
                     id="budget-input-amount",
                 )
 
-            with Horizontal(classes="form-field"):
-                yield Label("Commodity:")
+            with Horizontal(classes="form-field form-field--required"):
+                yield Label("Commodity:*")
                 default_commodity = load_default_commodity()
                 yield Input(
                     value=self.rule.amount.commodity if self.is_edit else default_commodity,
@@ -85,13 +85,15 @@ class BudgetFormScreen(ModalScreen[BudgetRule | None]):
                     id="budget-input-commodity",
                 )
 
-            with Horizontal(classes="form-field"):
+            with Horizontal(classes="form-field form-field--optional"):
                 yield Label("Category:")
                 yield Input(
                     value=self.rule.category if self.is_edit else "",
                     placeholder="e.g. Fixed, Variable, Food (optional)",
                     id="budget-input-category",
                 )
+
+            yield Static("* required", classes="form-required-footer")
 
             with Horizontal(id="budget-form-buttons"):
                 yield Button("Cancel", variant="default", id="btn-budget-cancel")

--- a/src/hledger_textual/screens/custom_report_form.py
+++ b/src/hledger_textual/screens/custom_report_form.py
@@ -53,16 +53,16 @@ class CustomReportFormScreen(ModalScreen[CustomReport | None]):
         with Vertical(id="custom-report-form-dialog"):
             yield Static(title, id="custom-report-form-title")
 
-            with Horizontal(classes="form-field"):
-                yield Label("Name:")
+            with Horizontal(classes="form-field form-field--required"):
+                yield Label("Name:*")
                 yield Input(
                     value=self.report.name if self.is_edit else "",
                     placeholder="e.g. Monthly expenses tree",
                     id="custom-report-input-name",
                 )
 
-            with Horizontal(classes="form-field"):
-                yield Label("Command:")
+            with Horizontal(classes="form-field form-field--required"):
+                yield Label("Command:*")
                 yield Input(
                     value=self.report.command if self.is_edit else "",
                     placeholder="e.g. balance expenses --tree -M",
@@ -74,6 +74,8 @@ class CustomReportFormScreen(ModalScreen[CustomReport | None]):
                 *[Option(f"{cmd}  [{desc}]", id=cmd) for cmd, desc in _EXAMPLES],
                 id="custom-report-examples",
             )
+
+            yield Static("* required", classes="form-required-footer")
 
             with Horizontal(id="custom-report-form-buttons"):
                 yield Button("Cancel", variant="default", id="btn-custom-report-cancel")

--- a/src/hledger_textual/screens/import_wizard.py
+++ b/src/hledger_textual/screens/import_wizard.py
@@ -107,15 +107,15 @@ class ImportWizardScreen(ModalScreen[tuple[Path, Path] | None]):
             # --- Step 0: CSV Preview ---
             with Vertical(id="wizard-step-0", classes="wizard-step"):
                 yield Static("CSV Preview", classes="wizard-step-title")
-                with Horizontal(classes="form-field"):
-                    yield Label("Separator:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Separator:*")
                     yield Select(
                         options=_SEPARATOR_OPTIONS,
                         value=",",
                         id="wizard-separator",
                     )
-                with Horizontal(classes="form-field"):
-                    yield Label("Header row:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Header row:*")
                     yield Select(
                         options=_HEADER_OPTIONS,
                         value="yes",
@@ -135,26 +135,26 @@ class ImportWizardScreen(ModalScreen[tuple[Path, Path] | None]):
             # --- Step 2: Basic Settings ---
             with Vertical(id="wizard-step-2", classes="wizard-step"):
                 yield Static("Settings", classes="wizard-step-title")
-                with Horizontal(classes="form-field"):
-                    yield Label("Rules name:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Rules name:*")
                     yield Input(
                         placeholder="e.g. UniCredit Checking",
                         id="wizard-rules-name",
                     )
-                with Horizontal(classes="form-field"):
-                    yield Label("Bank account:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Bank account:*")
                     yield AutocompleteInput(
                         placeholder="e.g. assets:bank:checking",
                         id="wizard-account1",
                     )
-                with Horizontal(classes="form-field"):
-                    yield Label("Currency:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Currency:*")
                     yield Input(
                         value=load_default_commodity(),
                         id="wizard-currency",
                     )
-                with Horizontal(classes="form-field"):
-                    yield Label("Date format:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Date format:*")
                     yield Input(
                         id="wizard-date-format",
                     )
@@ -179,6 +179,8 @@ class ImportWizardScreen(ModalScreen[tuple[Path, Path] | None]):
             with Vertical(id="wizard-step-4", classes="wizard-step"):
                 yield Static("Review & Save", classes="wizard-step-title")
                 yield TextArea(id="wizard-raw-editor")
+
+            yield Static("* required", classes="form-required-footer")
 
             # --- Navigation ---
             with Horizontal(id="wizard-nav-buttons"):

--- a/src/hledger_textual/screens/recurring_form.py
+++ b/src/hledger_textual/screens/recurring_form.py
@@ -89,24 +89,24 @@ class RecurringFormScreen(ModalScreen[RecurringRule | None]):
             yield Static(title, id="form-title")
 
             with VerticalScroll(id="form-scroll"):
-                with Horizontal(classes="form-field"):
-                    yield Label("Description:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Description:*")
                     yield Input(
                         value=r.description if r else "",
                         placeholder="e.g. Rent payment",
                         id="recurring-input-description",
                     )
 
-                with Horizontal(classes="form-field"):
-                    yield Label("Period:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Period:*")
                     yield Select(
                         options=_PERIOD_OPTIONS,
                         value=initial_period,
                         id="recurring-select-period",
                     )
 
-                with Horizontal(classes="form-field", id="recurring-custom-period-row"):
-                    yield Label("Expression:")
+                with Horizontal(classes="form-field form-field--required", id="recurring-custom-period-row"):
+                    yield Label("Expression:*")
                     yield Input(
                         value=initial_custom,
                         placeholder="e.g. every 2 weeks  (also: every 3 days, monthly)",
@@ -133,14 +133,14 @@ class RecurringFormScreen(ModalScreen[RecurringRule | None]):
                         classes="form-error",
                     )
 
-                with Horizontal(classes="form-field"):
-                    yield Label("Start date:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Start date:*")
                     yield DateInput(
                         value=r.start_date if (r and r.start_date) else date.today().isoformat(),
                         id="recurring-input-start",
                     )
 
-                with Horizontal(classes="form-field"):
+                with Horizontal(classes="form-field form-field--optional"):
                     yield Label("End date:")
                     yield DateInput(
                         value=r.end_date if (r and r.end_date) else "",
@@ -148,12 +148,14 @@ class RecurringFormScreen(ModalScreen[RecurringRule | None]):
                         id="recurring-input-end",
                     )
 
-                yield Static("Postings", id="postings-header")
+                yield Static("Postings*", id="postings-header")
                 yield Vertical(id="postings-container")
 
                 with Horizontal(id="posting-buttons"):
                     yield Button("\\[+] Add posting", id="btn-add-posting")
                     yield Button("\\[-] Remove last", id="btn-remove-posting")
+
+            yield Static("* required", classes="form-required-footer")
 
             with Horizontal(id="form-buttons"):
                 yield Button("Cancel", variant="default", id="btn-form-cancel")

--- a/src/hledger_textual/screens/transaction_form.py
+++ b/src/hledger_textual/screens/transaction_form.py
@@ -426,16 +426,16 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
 
             with VerticalScroll(id="form-scroll"):
                 # Date field
-                with Horizontal(classes="form-field"):
-                    yield Label("Date:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Date:*")
                     yield DateInput(
                         value=self.transaction.date if self._has_template else date.today().isoformat(),
                         id="input-date",
                     )
 
                 # Description field
-                with Horizontal(classes="form-field"):
-                    yield Label("Description:")
+                with Horizontal(classes="form-field form-field--required"):
+                    yield Label("Description:*")
                     yield AutocompleteInput(
                         value=self.transaction.description if self._has_template else "",
                         placeholder="Transaction description",
@@ -455,7 +455,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                     )
 
                 # Code field
-                with Horizontal(classes="form-field"):
+                with Horizontal(classes="form-field form-field--optional"):
                     yield Label("Code:")
                     yield Input(
                         value=self.transaction.code if self._has_template else "",
@@ -464,7 +464,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                     )
 
                 # Comment field
-                with Horizontal(classes="form-field"):
+                with Horizontal(classes="form-field form-field--optional"):
                     yield Label("Comment:")
                     yield Input(
                         value=self.transaction.comment if self._has_template else "",
@@ -473,7 +473,7 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                     )
 
                 # Postings section
-                yield Static("Postings", id="postings-header")
+                yield Static("Postings*", id="postings-header")
                 yield Static(
                     "Amount: plain number (50.00), currency prefix (€50.00), "
                     "or commodity with cost (-5 STCK @@ €200.00 / -5 STCK @ €40.00). "
@@ -490,6 +490,8 @@ class TransactionFormScreen(ModalScreen[Transaction | None]):
                 with Horizontal(id="posting-buttons"):
                     yield Button("\\[+] Add posting", id="btn-add-posting")
                     yield Button("\\[-] Remove last", id="btn-remove-posting")
+
+            yield Static("* required", classes="form-required-footer")
 
             with Horizontal(id="form-buttons"):
                 yield Button("Cancel", variant="default", id="btn-form-cancel")

--- a/src/hledger_textual/styles/app.tcss
+++ b/src/hledger_textual/styles/app.tcss
@@ -465,6 +465,23 @@ TransactionFormScreen {
     width: 1fr;
 }
 
+/* Required fields render the trailing "*" in $primary so the marker stands
+   out without changing the field layout. Optional fields use a muted label
+   colour so users can scan the form for what they need to fill in. */
+.form-field--required Label {
+    color: $primary;
+}
+
+.form-field--optional Label {
+    color: $text-muted;
+}
+
+.form-required-footer {
+    color: $text-muted;
+    margin-top: 1;
+    text-style: italic;
+}
+
 /* --- Postings Section --- */
 
 #postings-header {


### PR DESCRIPTION
## Summary

Required and optional fields across the app's forms were styled identically. New users hit a save error before learning which fields were mandatory. This PR adds explicit asterisks to required field labels, a `* required` footer note, and matching CSS classes (`.form-field--required` / `.form-field--optional`) across every form listed in the issue body.

Closes #141

## Why this matters

The issue describes a real onboarding paper cut: someone trying to create their first recurring rule, budget, or import flow has to fill in fields, hit Save, read the error, then guess what was actually required. The visual signal is cheap to add and matches the convention every other forms-heavy app uses.

The asterisk lives in the label text rather than being a pure CSS pseudo-element so it survives Textual's screen-reader / accessibility surface; the CSS class layers a `$primary` colour on required labels and a `$text-muted` colour on optional ones so the asterisk reads as deliberate, not decoration.

## Coverage of the acceptance criteria

The issue listed three checkboxes and one design hint:

- Asterisks on required field labels: applied across `transaction_form.py` (Date, Description), `recurring_form.py` (Description, Period, Expression when custom, Start date), `budget_form.py` (Account, Amount, Commodity), `custom_report_form.py` (Name, Command), and `import_wizard.py` (Separator, Header row in step 0; Rules name, Bank account, Currency, Date format in step 2). Transaction-form Postings header gets a trailing asterisk so the section reads as required without each dynamic posting row label (`#1:`, `#2:`, ...) carrying its own asterisk.
- Footer note: a `Static("* required", classes="form-required-footer")` sits above the Cancel/Save row in each of the four single-step forms, and a single shared footer covers the multi-step `import_wizard`.
- CSS class: `.form-field--required` and `.form-field--optional` added to `styles/app.tcss`, plus `.form-required-footer` for the trailing note.
- Design hint ("group optional fields visually OR muted colour"): muted colour applied via `.form-field--optional Label` rather than a structural regrouping, which keeps each form's existing tab order and visual order intact.

## A note on the two forms not covered by asterisks

`account_note_form.py` is the modal that edits a single TextArea (the note may be empty per the docstring). There are no field labels in that form, only a title (`Note for {account}`), so neither asterisks nor a `* required` footer apply: the form has no required-vs-optional distinction to communicate. The posting rows inside `transaction_form.py` keep their positional labels (`#1:`, `#2:`, ...) for the same reason - the asterisk reads more naturally on the `Postings*` section header than on each individual row.

## Verification

`uv run pytest tests/test_transaction_form.py tests/test_budget_form.py tests/test_custom_reports.py -q` -> 147 passed. The coverage gate is a project-wide threshold and only fires when running the full suite; running just the form tests shows 38% total coverage but all 147 tests pass.

No behavioural changes: validation, save handlers, and form data flow are untouched. The only edits are label text and CSS class names; the CSS additions sit at the end of the existing `.form-field` block.
