### PR TITLE
refactor(screens): share ConfirmModalBase for sync and cloud-sync screens

### DIFF
--- a/src/hledger_textual/screens/cloud_sync_confirm.py
+++ b/src/hledger_textual/screens/cloud_sync_confirm.py
@@ -2,44 +2,22 @@
 
 from __future__ import annotations
 
-from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.screen import ModalScreen
-from textual.widgets import Button, Label
+from hledger_textual.screens.confirm_base import ConfirmAction, ConfirmModalBase
 
 
-class CloudSyncConfirmModal(ModalScreen[str | None]):
+class CloudSyncConfirmModal(ConfirmModalBase[str]):
     """A modal dialog to choose a cloud sync action.
 
     Returns ``"upload"``, ``"download"``, or ``None`` (cancel).
     """
 
-    BINDINGS = [
-        ("escape", "cancel", "Cancel"),
-    ]
-
-    def compose(self) -> ComposeResult:
-        """Create the modal layout."""
-        with Vertical(id="cloud-sync-dialog"):
-            yield Label("Cloud Sync", id="cloud-sync-title")
-            yield Label(
-                "Upload your journal to the cloud or download from it?",
-                id="cloud-sync-summary",
-            )
-            with Horizontal(id="cloud-sync-buttons"):
-                yield Button("Cancel", variant="default", id="btn-cloud-cancel")
-                yield Button("Download", variant="warning", id="btn-cloud-download")
-                yield Button("Upload", variant="primary", id="btn-cloud-upload")
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Handle button presses."""
-        if event.button.id == "btn-cloud-upload":
-            self.dismiss("upload")
-        elif event.button.id == "btn-cloud-download":
-            self.dismiss("download")
-        else:
-            self.dismiss(None)
-
-    def action_cancel(self) -> None:
-        """Cancel cloud sync."""
-        self.dismiss(None)
+    def __init__(self) -> None:
+        super().__init__(
+            title="Cloud Sync",
+            summary="Upload your journal to the cloud or download from it?",
+            prefix="cloud-sync",
+            actions=[
+                ConfirmAction("Download", "download", "warning", "download"),
+                ConfirmAction("Upload", "upload", "primary", "upload"),
+            ],
+        )

--- a/src/hledger_textual/screens/confirm_base.py
+++ b/src/hledger_textual/screens/confirm_base.py
@@ -1,0 +1,83 @@
+"""Reusable base class for multi-action confirm modals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ConfirmAction(Generic[T]):
+    """One non-cancel button on a confirm modal.
+
+    The button id is composed as ``f"btn-{prefix}-{id_suffix}"`` so the
+    base class can route presses back to ``result`` without per-subclass
+    handler code.
+    """
+
+    label: str
+    id_suffix: str
+    variant: str
+    result: T
+
+
+class ConfirmModalBase(ModalScreen[T | None], Generic[T]):
+    """Generic confirm modal with one or more action buttons plus Cancel.
+
+    Subclasses pass title, summary, an id ``prefix`` used for every
+    composed widget (``{prefix}-dialog``, ``{prefix}-title``,
+    ``{prefix}-summary``, ``{prefix}-buttons``, ``btn-{prefix}-cancel``,
+    ``btn-{prefix}-{id_suffix}``), and a list of :class:`ConfirmAction`
+    entries. Escape and the Cancel button both dismiss with ``None``;
+    every other button dismisses with the matching ``result``.
+    """
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        summary: str,
+        prefix: str,
+        actions: list[ConfirmAction[T]],
+        cancel_label: str = "Cancel",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._summary = summary
+        self._prefix = prefix
+        self._actions = actions
+        self._cancel_label = cancel_label
+        self._result_by_id: dict[str, T] = {
+            f"btn-{prefix}-{action.id_suffix}": action.result for action in actions
+        }
+
+    def compose(self) -> ComposeResult:
+        p = self._prefix
+        with Vertical(id=f"{p}-dialog"):
+            yield Label(self._title, id=f"{p}-title")
+            yield Label(self._summary, id=f"{p}-summary")
+            with Horizontal(id=f"{p}-buttons"):
+                yield Button(self._cancel_label, variant="default", id=f"btn-{p}-cancel")
+                for action in self._actions:
+                    yield Button(action.label, variant=action.variant, id=f"btn-{p}-{action.id_suffix}")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        btn_id = event.button.id or ""
+        if btn_id in self._result_by_id:
+            self.dismiss(self._result_by_id[btn_id])
+        else:
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/src/hledger_textual/screens/sync_confirm.py
+++ b/src/hledger_textual/screens/sync_confirm.py
@@ -2,66 +2,34 @@
 
 from __future__ import annotations
 
-from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.screen import ModalScreen
-from textual.widgets import Button, Label
-
+from hledger_textual.screens.confirm_base import ConfirmAction, ConfirmModalBase
 from hledger_textual.sync import SyncBackend
 
 
-class SyncConfirmModal(ModalScreen[str | None]):
+class SyncConfirmModal(ConfirmModalBase[str]):
     """A modal dialog to confirm and choose a sync action.
 
     Adapts its buttons to the backend's available actions.
     Returns the chosen action string, or ``None`` on cancel.
     """
 
-    BINDINGS = [
-        ("escape", "cancel", "Cancel"),
-    ]
-
     def __init__(self, backend: SyncBackend) -> None:
-        """Initialize the modal.
-
-        Args:
-            backend: The sync backend to display actions for.
-        """
-        super().__init__()
-        self._backend = backend
-
-    def compose(self) -> ComposeResult:
-        """Create the modal layout."""
-        with Vertical(id="sync-dialog"):
-            yield Label(f"Sync ({self._backend.name})", id="sync-title")
-            yield Label(self._backend.confirm_message(), id="sync-summary")
-            with Horizontal(id="sync-buttons"):
-                yield Button("Cancel", variant="default", id="btn-sync-cancel")
-                actions = self._backend.actions
-                if len(actions) == 1:
-                    yield Button(
-                        actions[0].capitalize(),
-                        variant="primary",
-                        id=f"btn-sync-{actions[0]}",
-                    )
-                else:
-                    for action in actions:
-                        variant = "primary" if action == actions[-1] else "warning"
-                        yield Button(
-                            action.capitalize(),
-                            variant=variant,
-                            id=f"btn-sync-{action}",
-                        )
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Handle button presses."""
-        btn_id = event.button.id or ""
-        if btn_id.startswith("btn-sync-") and btn_id != "btn-sync-cancel":
-            action = btn_id.removeprefix("btn-sync-")
-            self.dismiss(action)
+        actions = backend.actions
+        if len(actions) == 1:
+            confirm_actions = [ConfirmAction(actions[0].capitalize(), actions[0], "primary", actions[0])]
         else:
-            self.dismiss(None)
-
-    def action_cancel(self) -> None:
-        """Cancel sync."""
-        self.dismiss(None)
+            confirm_actions = [
+                ConfirmAction(
+                    action.capitalize(),
+                    action,
+                    "primary" if action == actions[-1] else "warning",
+                    action,
+                )
+                for action in actions
+            ]
+        super().__init__(
+            title=f"Sync ({backend.name})",
+            summary=backend.confirm_message(),
+            prefix="sync",
+            actions=confirm_actions,
+        )


### PR DESCRIPTION
## Summary

`CloudSyncConfirmModal` and `SyncConfirmModal` were hand-rolling the same modal scaffolding (Vertical container, title and summary Labels, Horizontal button bar, Escape binding, button dispatch) instead of sharing infrastructure. Per #115 option 2, this pulls the scaffold into a generic `ConfirmModalBase[T]` parameterised by title, summary, CSS id prefix, and a list of `ConfirmAction[T]` entries, and migrates both sync screens to use it. Net result is roughly 54 lines of scaffolding removed; each subclass now declares only its content.

`DeleteConfirmBase` is intentionally untouched (its result type is `bool`, its delete-button styling is wired through CSS rules on `#btn-delete` and friends, and the issue called out keeping the deletes alone unless we wanted to migrate them too). `MoveConfirmModal` is also out of scope because it embeds a `DateInput` rather than a plain confirm.

The existing CSS ids (`#sync-dialog`, `#sync-title`, `#sync-summary`, `#sync-buttons`, `#cloud-sync-dialog`, ...) are preserved exactly, so the rules in `src/hledger_textual/styles/app.tcss` keep matching without any styling work. Button id format is now uniform (`btn-{prefix}-cancel`, `btn-{prefix}-{action}`), which is invisible to users since no CSS rule or test referenced the old `btn-cloud-*` ids.

## Why this matters

The reporter flagged the scaffolding duplication and the bug-class it invites: two near-identical compose blocks plus two near-identical `on_button_pressed` dispatches drift apart over time as new buttons or variants get added to one but not the other. Funneling them through a single base also makes the action set declarative, which makes future modals (a third sync provider, an export action picker, anything multi-action) a five-line subclass rather than another scaffold copy.

## Verification

Ran the full pytest suite via the project's standard invocation:

    python -m pytest tests/ --no-cov -q

Result: 1152 passed in 6m43s. `ruff check src/` is clean. Smoke-tested instantiation of both sync screens to confirm no regression at the import or constructor boundary. No UX change is visible to users -- title, summary text, button labels, variants, and result values are all preserved from the prior implementations.

Closes #115

AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.
