### PR TITLE
feat(reports): add h/l key vim style navigation in reports pane

### DIFF
--- a/src/hledger_textual/widgets/pane_mixin.py
+++ b/src/hledger_textual/widgets/pane_mixin.py
@@ -40,6 +40,14 @@ class DataTablePaneMixin:
         """Move cursor up in the table."""
         self._get_main_table().action_cursor_up()
 
+    def action_cursor_left(self) -> None:
+        """Move cursor left in the table."""
+        self._get_main_table().action_cursor_left()
+
+    def action_cursor_right(self) -> None:
+        """Move cursor right in the table."""
+        self._get_main_table().action_cursor_right()
+
     def get_export_data(self):
         """Return an :class:`ExportData` for the currently visible table data.
 

--- a/src/hledger_textual/widgets/reports_pane.py
+++ b/src/hledger_textual/widgets/reports_pane.py
@@ -200,6 +200,8 @@ class ReportsPane(DataTablePaneMixin, Widget):
         Binding("escape", "back_to_builtin", "Back", show=False),
         Binding("j", "cursor_down", "Down", show=False),
         Binding("k", "cursor_up", "Up", show=False),
+        Binding("h", "cursor_left", "Left", show=False),
+        Binding("l", "cursor_right", "Right", show=False),
     ]
 
     def __init__(self, journal_file: Path, cache: HledgerCache | None = None, **kwargs) -> None:

--- a/tests/test_reports_pane.py
+++ b/tests/test_reports_pane.py
@@ -171,6 +171,58 @@ class TestReportsPaneReload:
             assert call_count > initial_count
 
 
+class TestReportsPaneVimNavigation:
+    """Tests for h/j/k/l vim-style cursor navigation in ReportsPane."""
+
+    async def test_l_key_moves_cursor_right(
+        self, reports_journal: Path, monkeypatch
+    ):
+        """Pressing 'l' advances the cell cursor to the next column."""
+        from hledger_textual.hledger import _parse_report_csv
+
+        data = _parse_report_csv(_SAMPLE_IS_CSV)
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report",
+            lambda *args, **kwargs: data,
+        )
+        app = _ReportsApp(reports_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.5)
+            table = app.query_one("#reports-table", DataTable)
+            table.move_cursor(row=1, column=0)
+            await pilot.pause()
+            assert table.cursor_column == 0
+
+            app.query_one(ReportsPane).focus()
+            await pilot.press("l")
+            await pilot.pause()
+            assert table.cursor_column == 1
+
+    async def test_h_key_moves_cursor_left(
+        self, reports_journal: Path, monkeypatch
+    ):
+        """Pressing 'h' moves the cell cursor back one column."""
+        from hledger_textual.hledger import _parse_report_csv
+
+        data = _parse_report_csv(_SAMPLE_IS_CSV)
+        monkeypatch.setattr(
+            "hledger_textual.widgets.reports_pane.load_report",
+            lambda *args, **kwargs: data,
+        )
+        app = _ReportsApp(reports_journal)
+        async with app.run_test() as pilot:
+            await pilot.pause(delay=0.5)
+            table = app.query_one("#reports-table", DataTable)
+            table.move_cursor(row=1, column=1)
+            await pilot.pause()
+            assert table.cursor_column == 1
+
+            app.query_one(ReportsPane).focus()
+            await pilot.press("h")
+            await pilot.pause()
+            assert table.cursor_column == 0
+
+
 class TestReportsPaneErrors:
     """Tests for error handling in ReportsPane."""
 


### PR DESCRIPTION
This PR adds vim key based navigation to the reports pane. This allows the user to move between columns with the h/l keys (j/k already works).

The reports DataTable already uses cursor_type="cell", so wiring the bindings through new action_cursor_left/right forwarders on DataTablePaneMixin is enough.