### PR TITLE
release: v0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.3.5"
+version = "0.3.6"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary

- Bump hledger-textual from 0.3.5 to 0.3.6 in pyproject.toml.
- Update uv.lock to match the release version.

## Validation

- uv lock --check
- uv run ruff check src tests
- uv run pytest -q (1154 passed, coverage 78.38%)

## Release notes

This release includes the merged v0.3.6 milestone PRs: confirm modal refactor, reports h/l vim navigation, and transaction-pane move-test stabilization.