### PR TITLE
chore: bump version to v0.3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hledger-textual"
-version = "0.3.6"
+version = "0.3.7"
 description = "A full-featured terminal user interface for hledger plain-text accounting"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "hledger-textual"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
Version bump for the v0.3.7 release, which includes multicurrency balance sheet support (issue #207).